### PR TITLE
feat(meguru): Cloudflare Workers + R2アーキテクチャへの移行 (v1.0.0)

### DIFF
--- a/.github/workflows/deploy-meguru-collector.yml
+++ b/.github/workflows/deploy-meguru-collector.yml
@@ -1,0 +1,34 @@
+name: Deploy meguru-collector
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/meguru/collector/**'
+      - 'packages/meguru/types/**'
+
+jobs:
+  deploy:
+    name: Deploy collector worker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build shared types
+        run: bun run --filter '@meguru/types' build
+
+      - name: Type check
+        run: bun run --filter '@meguru/collector' typecheck
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          workingDirectory: apps/meguru/collector
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-meguru-dashboard.yml
+++ b/.github/workflows/deploy-meguru-dashboard.yml
@@ -1,0 +1,34 @@
+name: Deploy meguru-dashboard
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/meguru/dashboard/**'
+      - 'packages/meguru/types/**'
+
+jobs:
+  deploy:
+    name: Deploy dashboard worker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build shared types
+        run: bun run --filter '@meguru/types' build
+
+      - name: Type check
+        run: bun run --filter '@meguru/dashboard' typecheck
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          workingDirectory: apps/meguru/dashboard
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-meguru-gateway.yml
+++ b/.github/workflows/deploy-meguru-gateway.yml
@@ -1,0 +1,34 @@
+name: Deploy meguru-gateway
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/meguru/gateway/**'
+      - 'packages/meguru/types/**'
+
+jobs:
+  deploy:
+    name: Deploy gateway worker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build shared types
+        run: bun run --filter '@meguru/types' build
+
+      - name: Type check
+        run: bun run --filter '@meguru/gateway' typecheck
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          workingDirectory: apps/meguru/gateway
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/deploy-meguru-repository.yml
+++ b/.github/workflows/deploy-meguru-repository.yml
@@ -1,0 +1,34 @@
+name: Deploy meguru-repository
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/meguru/repository/**'
+      - 'packages/meguru/types/**'
+
+jobs:
+  deploy:
+    name: Deploy repository worker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build shared types
+        run: bun run --filter '@meguru/types' build
+
+      - name: Type check
+        run: bun run --filter '@meguru/repository' typecheck
+
+      - name: Deploy
+        uses: cloudflare/wrangler-action@v3
+        with:
+          workingDirectory: apps/meguru/repository
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/apps/meguru/cli/package.json
+++ b/apps/meguru/cli/package.json
@@ -4,11 +4,12 @@
   "private": true,
   "type": "module",
   "bin": {
-    "meguru": "./src/index.ts"
+    "meguru": "./dist/meguru"
   },
   "scripts": {
     "start": "bun run src/index.ts",
     "build": "bun build src/index.ts --outfile dist/meguru --target bun --sourcemap",
+    "prepack": "bun run build",
     "typecheck": "tsc --noEmit",
     "lint": "biome check --write .",
     "lint:check": "biome check .",

--- a/apps/meguru/cli/package.json
+++ b/apps/meguru/cli/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@meguru/cli",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "meguru": "./src/index.ts"
+  },
+  "scripts": {
+    "start": "bun run src/index.ts",
+    "build": "bun build src/index.ts --outfile dist/meguru --target bun --sourcemap",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check --write .",
+    "lint:check": "biome check .",
+    "clean": "rm -rf dist node_modules"
+  },
+  "dependencies": {
+    "@meguru/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "bun-types": "^1.3.11",
+    "typescript": "catalog:"
+  }
+}

--- a/apps/meguru/cli/src/index.ts
+++ b/apps/meguru/cli/src/index.ts
@@ -79,7 +79,23 @@ const command = args[0] ?? '';
 
 function getFlag(name: string, fallback: string): string {
   const idx = args.indexOf(`--${name}`);
-  return idx >= 0 && args[idx + 1] != null ? (args[idx + 1] as string) : fallback;
+  if (idx < 0) return fallback;
+  const value = args[idx + 1];
+  if (value == null || value.startsWith('--')) {
+    console.error(`[meguru] Missing value for --${name}`);
+    process.exit(1);
+  }
+  return value;
+}
+
+function getPositiveIntFlag(name: string, fallback: number): number {
+  const raw = getFlag(name, String(fallback));
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    console.error(`[meguru] Invalid --${name}: "${raw}" (must be a positive integer)`);
+    process.exit(1);
+  }
+  return parsed;
 }
 
 const VALID_FORMATS = new Set<OutputFormat>(['json', 'table', 'text']);
@@ -98,8 +114,8 @@ if (!VALID_PERIODS.has(rawPeriod)) {
 }
 const period = rawPeriod;
 
-const limit = getFlag('limit', '20');
-const days = getFlag('days', '30');
+const limit = getPositiveIntFlag('limit', 20);
+const days = getPositiveIntFlag('days', 30);
 
 // ----------------------------------------------------------------
 // Commands

--- a/apps/meguru/cli/src/index.ts
+++ b/apps/meguru/cli/src/index.ts
@@ -15,13 +15,18 @@ const GATEWAY_URL =
 
 async function fetchApi<T>(path: string): Promise<T> {
   const url = `${GATEWAY_URL}${path}`;
-  const response = await fetch(url);
-  if (!response.ok) {
-    const text = await response.text().catch(() => '');
-    console.error(`[meguru] API error ${response.status}: ${text}`, { url });
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      console.error(`[meguru] API error ${response.status}: ${text}`, { url });
+      process.exit(1);
+    }
+    return (await response.json()) as T;
+  } catch (err) {
+    console.error('[meguru] Request failed', { url, error: err });
     process.exit(1);
   }
-  return response.json() as Promise<T>;
 }
 
 // ----------------------------------------------------------------
@@ -49,10 +54,20 @@ function toTable(rows: Record<string, unknown>[]): string {
 function print(data: unknown, format: OutputFormat): void {
   if (format === 'json') {
     process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
-  } else if (format === 'table' && Array.isArray(data)) {
-    process.stdout.write(`${toTable(data as Record<string, unknown>[])}\n`);
-  } else {
-    process.stdout.write(`${String(data)}\n`);
+  } else if (format === 'table') {
+    const rows = Array.isArray(data)
+      ? (data as Record<string, unknown>[])
+      : [data as Record<string, unknown>];
+    process.stdout.write(`${toTable(rows)}\n`);
+  } else if (format === 'text') {
+    if (Array.isArray(data)) {
+      // Render array as newline-separated JSON lines for text mode
+      for (const item of data as unknown[]) {
+        process.stdout.write(`${JSON.stringify(item)}\n`);
+      }
+    } else {
+      process.stdout.write(`${String(data)}\n`);
+    }
   }
 }
 

--- a/apps/meguru/cli/src/index.ts
+++ b/apps/meguru/cli/src/index.ts
@@ -83,8 +83,22 @@ function getFlag(name: string, fallback: string): string {
   return idx >= 0 && args[idx + 1] != null ? (args[idx + 1] as string) : fallback;
 }
 
-const format = getFlag('format', 'json') as OutputFormat;
-const period = getFlag('period', 'weekly');
+const VALID_FORMATS = new Set<OutputFormat>(['json', 'table', 'text']);
+const rawFormat = getFlag('format', 'json');
+if (!VALID_FORMATS.has(rawFormat as OutputFormat)) {
+  console.error(`[meguru] Invalid format: "${rawFormat}". Valid: json, table, text`);
+  process.exit(1);
+}
+const format = rawFormat as OutputFormat;
+
+const VALID_PERIODS = new Set(['daily', 'weekly', 'monthly']);
+const rawPeriod = getFlag('period', 'weekly');
+if (!VALID_PERIODS.has(rawPeriod)) {
+  console.error(`[meguru] Invalid period: "${rawPeriod}". Valid: daily, weekly, monthly`);
+  process.exit(1);
+}
+const period = rawPeriod;
+
 const limit = getFlag('limit', '20');
 const days = getFlag('days', '30');
 

--- a/apps/meguru/cli/src/index.ts
+++ b/apps/meguru/cli/src/index.ts
@@ -18,12 +18,12 @@ async function fetchApi<T>(path: string): Promise<T> {
   try {
     const response = await fetch(url);
     if (!response.ok) {
-      console.error(`[meguru] API error ${response.status}`, { url });
+      console.error(`[meguru] API error ${response.status}`);
       process.exit(1);
     }
     return (await response.json()) as T;
   } catch (err) {
-    console.error('[meguru] Request failed', { url, error: err });
+    console.error('[meguru] Request failed', { error: err });
     process.exit(1);
   }
 }

--- a/apps/meguru/cli/src/index.ts
+++ b/apps/meguru/cli/src/index.ts
@@ -18,8 +18,7 @@ async function fetchApi<T>(path: string): Promise<T> {
   try {
     const response = await fetch(url);
     if (!response.ok) {
-      const text = await response.text().catch(() => '');
-      console.error(`[meguru] API error ${response.status}: ${text}`, { url });
+      console.error(`[meguru] API error ${response.status}`, { url });
       process.exit(1);
     }
     return (await response.json()) as T;
@@ -191,7 +190,26 @@ switch (command) {
       fetchApi<CategorySummary[]>('/api/categories'),
     ]);
 
-    if (format === 'text') {
+    if (format === 'table') {
+      process.stdout.write('=== Top 5 Trending ===\n');
+      print(
+        trending.map((t) => ({
+          name: t.name,
+          installs: t.install_count ?? '-',
+          trending: t.trending_weekly ?? '-',
+        })),
+        'table',
+      );
+      process.stdout.write('\n=== Top Categories ===\n');
+      print(
+        categories.slice(0, 5).map((c) => ({
+          category: c.category,
+          extensions: c.total_extensions,
+          installs: c.total_installs,
+        })),
+        'table',
+      );
+    } else if (format === 'text') {
       process.stdout.write(`=== Top 5 Trending (${period}) ===\n`);
       for (const [i, t] of trending.entries()) {
         process.stdout.write(

--- a/apps/meguru/cli/src/index.ts
+++ b/apps/meguru/cli/src/index.ts
@@ -5,9 +5,12 @@ import type { CategorySummary, GrowthPoint, SearchResult, TrendingItem } from '@
 // Config
 // ----------------------------------------------------------------
 
-const GATEWAY_URL =
-  // biome-ignore lint/complexity/useLiteralKeys: tsconfig strictest requires bracket notation for index signatures
-  process.env['MEGURU_GATEWAY_URL'] ?? 'https://meguru-gateway.example.workers.dev';
+// biome-ignore lint/complexity/useLiteralKeys: tsconfig strictest requires bracket notation for index signatures
+const GATEWAY_URL = process.env['MEGURU_GATEWAY_URL'];
+if (!GATEWAY_URL) {
+  console.error('[meguru] MEGURU_GATEWAY_URL environment variable is required');
+  process.exit(1);
+}
 
 // ----------------------------------------------------------------
 // API client
@@ -261,7 +264,7 @@ switch (command) {
         '  --days     30 (default)',
         '',
         'Environment:',
-        '  MEGURU_GATEWAY_URL   Gateway URL (default: https://meguru-gateway.example.workers.dev)',
+        '  MEGURU_GATEWAY_URL   Gateway URL (required)',
         '',
         'Examples:',
         '  meguru trending --period weekly --limit 20 --format table',

--- a/apps/meguru/cli/src/index.ts
+++ b/apps/meguru/cli/src/index.ts
@@ -1,0 +1,213 @@
+#!/usr/bin/env bun
+import type { CategorySummary, GrowthPoint, SearchResult, TrendingItem } from '@meguru/types';
+
+// ----------------------------------------------------------------
+// Config
+// ----------------------------------------------------------------
+
+const GATEWAY_URL =
+  // biome-ignore lint/complexity/useLiteralKeys: tsconfig strictest requires bracket notation for index signatures
+  process.env['MEGURU_GATEWAY_URL'] ?? 'https://meguru-gateway.example.workers.dev';
+
+// ----------------------------------------------------------------
+// API client
+// ----------------------------------------------------------------
+
+async function fetchApi<T>(path: string): Promise<T> {
+  const url = `${GATEWAY_URL}${path}`;
+  const response = await fetch(url);
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    console.error(`[meguru] API error ${response.status}: ${text}`, { url });
+    process.exit(1);
+  }
+  return response.json() as Promise<T>;
+}
+
+// ----------------------------------------------------------------
+// Output formatters
+// ----------------------------------------------------------------
+
+type OutputFormat = 'json' | 'table' | 'text';
+
+function toTable(rows: Record<string, unknown>[]): string {
+  if (rows.length === 0) return '(no results)';
+  const first = rows[0];
+  if (!first) return '(no results)';
+  const keys = Object.keys(first);
+  const colWidths = keys.map((k) =>
+    Math.max(k.length, ...rows.map((r) => String(r[k] ?? '').length)),
+  );
+  const header = keys.map((k, i) => k.padEnd(colWidths[i] ?? 0)).join('  ');
+  const divider = colWidths.map((w) => '-'.repeat(w)).join('  ');
+  const body = rows.map((r) =>
+    keys.map((k, i) => String(r[k] ?? '').padEnd(colWidths[i] ?? 0)).join('  '),
+  );
+  return [header, divider, ...body].join('\n');
+}
+
+function print(data: unknown, format: OutputFormat): void {
+  if (format === 'json') {
+    process.stdout.write(`${JSON.stringify(data, null, 2)}\n`);
+  } else if (format === 'table' && Array.isArray(data)) {
+    process.stdout.write(`${toTable(data as Record<string, unknown>[])}\n`);
+  } else {
+    process.stdout.write(`${String(data)}\n`);
+  }
+}
+
+// ----------------------------------------------------------------
+// Argument helpers
+// ----------------------------------------------------------------
+
+const args = process.argv.slice(2);
+const command = args[0] ?? '';
+
+function getFlag(name: string, fallback: string): string {
+  const idx = args.indexOf(`--${name}`);
+  return idx >= 0 && args[idx + 1] != null ? (args[idx + 1] as string) : fallback;
+}
+
+const format = getFlag('format', 'json') as OutputFormat;
+const period = getFlag('period', 'weekly');
+const limit = getFlag('limit', '20');
+const days = getFlag('days', '30');
+
+// ----------------------------------------------------------------
+// Commands
+// ----------------------------------------------------------------
+
+switch (command) {
+  // meguru trending [--period weekly|daily|monthly] [--limit 20] [--format json|table|text]
+  case 'trending': {
+    const data = await fetchApi<TrendingItem[]>(`/api/trending?period=${period}&limit=${limit}`);
+    if (format === 'table') {
+      print(
+        data.map((d) => ({
+          name: d.name,
+          installs: d.install_count ?? '-',
+          trending_weekly: d.trending_weekly ?? '-',
+          rating: d.average_rating?.toFixed(1) ?? '-',
+        })),
+        format,
+      );
+    } else {
+      print(data, format);
+    }
+    break;
+  }
+
+  // meguru growth <extensionId> [--days 30] [--format json|table|text]
+  case 'growth': {
+    const extensionId = args[1];
+    if (!extensionId) {
+      console.error('Usage: meguru growth <extensionId> [--days 30]');
+      process.exit(1);
+    }
+    const data = await fetchApi<GrowthPoint[]>(
+      `/api/growth?id=${encodeURIComponent(extensionId)}&days=${days}`,
+    );
+    print(data, format);
+    break;
+  }
+
+  // meguru categories [--format json|table|text]
+  case 'categories': {
+    const data = await fetchApi<CategorySummary[]>('/api/categories');
+    if (format === 'table') {
+      print(
+        data.map((d) => ({
+          category: d.category,
+          extensions: d.total_extensions,
+          total_installs: d.total_installs,
+        })),
+        format,
+      );
+    } else {
+      print(data, format);
+    }
+    break;
+  }
+
+  // meguru search <query> [--limit 50] [--format json|table|text]
+  case 'search': {
+    const query = args[1];
+    if (!query) {
+      console.error('Usage: meguru search <query>');
+      process.exit(1);
+    }
+    const data = await fetchApi<SearchResult[]>(
+      `/api/search?q=${encodeURIComponent(query)}&limit=${limit}`,
+    );
+    if (format === 'table') {
+      print(
+        data.map((d) => ({
+          name: d.name,
+          publisher: d.publisher_name,
+          installs: d.install_count ?? '-',
+          description: (d.short_description ?? '').slice(0, 60),
+        })),
+        format,
+      );
+    } else {
+      print(data, format);
+    }
+    break;
+  }
+
+  // meguru summary [--format json|text]
+  case 'summary': {
+    const [trending, categories] = await Promise.all([
+      fetchApi<TrendingItem[]>(`/api/trending?period=${period}&limit=5`),
+      fetchApi<CategorySummary[]>('/api/categories'),
+    ]);
+
+    if (format === 'text') {
+      process.stdout.write(`=== Top 5 Trending (${period}) ===\n`);
+      for (const [i, t] of trending.entries()) {
+        process.stdout.write(
+          `${i + 1}. ${t.display_name} (${t.publisher_name}) — installs: ${t.install_count ?? '?'}\n`,
+        );
+      }
+      process.stdout.write('\n=== Top Categories ===\n');
+      for (const [i, c] of categories.slice(0, 5).entries()) {
+        process.stdout.write(`${i + 1}. ${c.category} — ${c.total_extensions} extensions\n`);
+      }
+    } else {
+      print({ trending, categories }, format);
+    }
+    break;
+  }
+
+  default: {
+    process.stderr.write(
+      `${[
+        'meguru — VSCode Marketplace Trend Tracker CLI',
+        '',
+        'Commands:',
+        '  trending   [--period weekly|daily|monthly] [--limit N]',
+        '  growth     <extensionId> [--days N]',
+        '  categories',
+        '  search     <query> [--limit N]',
+        '  summary    [--format json|text]',
+        '',
+        'Options:',
+        '  --format   json (default) | table | text',
+        '  --period   weekly (default) | daily | monthly',
+        '  --limit    20 (default)',
+        '  --days     30 (default)',
+        '',
+        'Environment:',
+        '  MEGURU_GATEWAY_URL   Gateway URL (default: https://meguru-gateway.example.workers.dev)',
+        '',
+        'Examples:',
+        '  meguru trending --period weekly --limit 20 --format table',
+        '  meguru growth ms-python.python --days 30',
+        '  meguru search "copilot" --format table',
+        '  meguru summary --format text',
+      ].join('\n')}\n`,
+    );
+    if (command) process.exit(1);
+    break;
+  }
+}

--- a/apps/meguru/cli/tsconfig.json
+++ b/apps/meguru/cli/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@tsconfig/strictest",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "types": ["bun-types"],
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/apps/meguru/collector/package.json
+++ b/apps/meguru/collector/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@meguru/collector",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check --write .",
+    "lint:check": "biome check .",
+    "clean": "rm -rf .wrangler node_modules"
+  },
+  "dependencies": {
+    "@meguru/types": "workspace:*",
+    "hono": "^4.7.5"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@cloudflare/workers-types": "^4.20250409.0",
+    "typescript": "catalog:",
+    "wrangler": "^3.114.0"
+  }
+}

--- a/apps/meguru/collector/src/index.ts
+++ b/apps/meguru/collector/src/index.ts
@@ -5,6 +5,8 @@ import { SortBy, queryExtensions, toExtensionSnapshot } from './marketplace-api.
 interface Env {
   REPOSITORY: Fetcher;
   CRAWL_QUEUE: Queue<CrawlQueueMessage>;
+  TRIGGER_SECRET: string;
+  INTERNAL_SECRET: string;
 }
 
 const PAGE_SIZE = 100;
@@ -18,7 +20,12 @@ function todayISO(): string {
 // ----------------------------------------------------------------
 const app = new Hono<{ Bindings: Env }>();
 
-app.get('/trigger', async (c) => {
+// POST /trigger — protected by TRIGGER_SECRET env var
+app.post('/trigger', async (c) => {
+  const provided = c.req.header('X-Trigger-Secret');
+  if (!c.env.TRIGGER_SECRET || provided !== c.env.TRIGGER_SECRET) {
+    return c.json({ error: 'Unauthorized' }, 401);
+  }
   await enqueueFirstPage(c.env, todayISO());
   return c.json({ ok: true, message: 'Collection triggered' });
 });
@@ -31,6 +38,19 @@ app.get('/health', (c) => c.json({ ok: true }));
 async function enqueueFirstPage(env: Env, snapshotDate: string): Promise<void> {
   await env.CRAWL_QUEUE.send({ pageNumber: 1, snapshotDate });
   console.log(`[collector] Enqueued page 1 for ${snapshotDate}`);
+}
+
+// ----------------------------------------------------------------
+// Invalidate caches (checks response status)
+// ----------------------------------------------------------------
+async function invalidateRepositoryCaches(env: Env): Promise<void> {
+  const res = await env.REPOSITORY.fetch('http://internal/invalidate', {
+    method: 'POST',
+    headers: { 'X-Internal-Secret': env.INTERNAL_SECRET },
+  });
+  if (!res.ok) {
+    throw new Error(`Repository invalidate failed: ${res.status} ${res.statusText}`);
+  }
 }
 
 // ----------------------------------------------------------------
@@ -47,8 +67,7 @@ async function processPage(env: Env, pageNumber: number, snapshotDate: string): 
 
   if (extensions.length === 0) {
     console.log(`[collector] Page ${pageNumber} empty — collection complete`);
-    // Invalidate caches now that collection is done
-    await env.REPOSITORY.fetch('http://internal/invalidate', { method: 'POST' });
+    await invalidateRepositoryCaches(env);
     return;
   }
 
@@ -56,8 +75,11 @@ async function processPage(env: Env, pageNumber: number, snapshotDate: string): 
 
   const res = await env.REPOSITORY.fetch('http://internal/write', {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ date: snapshotDate, records }),
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Internal-Secret': env.INTERNAL_SECRET,
+    },
+    body: JSON.stringify({ date: snapshotDate, chunkId: `page-${pageNumber}`, records }),
   });
 
   if (!res.ok) {
@@ -66,12 +88,10 @@ async function processPage(env: Env, pageNumber: number, snapshotDate: string): 
 
   console.log(`[collector] Page ${pageNumber}: wrote ${records.length} records`);
 
-  // Enqueue next page if there are more results
   if (extensions.length === PAGE_SIZE) {
     await env.CRAWL_QUEUE.send({ pageNumber: pageNumber + 1, snapshotDate });
   } else {
-    // Last page — invalidate caches
-    await env.REPOSITORY.fetch('http://internal/invalidate', { method: 'POST' });
+    await invalidateRepositoryCaches(env);
     console.log(`[collector] Collection complete for ${snapshotDate}`);
   }
 }

--- a/apps/meguru/collector/src/index.ts
+++ b/apps/meguru/collector/src/index.ts
@@ -1,0 +1,106 @@
+import type { CrawlQueueMessage } from '@meguru/types';
+import { Hono } from 'hono';
+import { SortBy, queryExtensions, toExtensionSnapshot } from './marketplace-api.js';
+
+interface Env {
+  REPOSITORY: Fetcher;
+  CRAWL_QUEUE: Queue<CrawlQueueMessage>;
+}
+
+const PAGE_SIZE = 100;
+
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// ----------------------------------------------------------------
+// HTTP handler (manual trigger / health check)
+// ----------------------------------------------------------------
+const app = new Hono<{ Bindings: Env }>();
+
+app.get('/trigger', async (c) => {
+  await enqueueFirstPage(c.env, todayISO());
+  return c.json({ ok: true, message: 'Collection triggered' });
+});
+
+app.get('/health', (c) => c.json({ ok: true }));
+
+// ----------------------------------------------------------------
+// Enqueue the first page to kick off collection
+// ----------------------------------------------------------------
+async function enqueueFirstPage(env: Env, snapshotDate: string): Promise<void> {
+  await env.CRAWL_QUEUE.send({ pageNumber: 1, snapshotDate });
+  console.log(`[collector] Enqueued page 1 for ${snapshotDate}`);
+}
+
+// ----------------------------------------------------------------
+// Process a single page from the Queue
+// ----------------------------------------------------------------
+async function processPage(env: Env, pageNumber: number, snapshotDate: string): Promise<void> {
+  console.log(`[collector] Processing page ${pageNumber} for ${snapshotDate}`);
+
+  const extensions = await queryExtensions({
+    sortBy: SortBy.Installs,
+    pageSize: PAGE_SIZE,
+    pageNumber,
+  });
+
+  if (extensions.length === 0) {
+    console.log(`[collector] Page ${pageNumber} empty — collection complete`);
+    // Invalidate caches now that collection is done
+    await env.REPOSITORY.fetch('http://internal/invalidate', { method: 'POST' });
+    return;
+  }
+
+  const records = extensions.map((ext) => toExtensionSnapshot(ext, snapshotDate));
+
+  const res = await env.REPOSITORY.fetch('http://internal/write', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ date: snapshotDate, records }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Repository write failed: ${res.status} ${res.statusText}`);
+  }
+
+  console.log(`[collector] Page ${pageNumber}: wrote ${records.length} records`);
+
+  // Enqueue next page if there are more results
+  if (extensions.length === PAGE_SIZE) {
+    await env.CRAWL_QUEUE.send({ pageNumber: pageNumber + 1, snapshotDate });
+  } else {
+    // Last page — invalidate caches
+    await env.REPOSITORY.fetch('http://internal/invalidate', { method: 'POST' });
+    console.log(`[collector] Collection complete for ${snapshotDate}`);
+  }
+}
+
+// ----------------------------------------------------------------
+// Worker export (fetch + scheduled + queue)
+// ----------------------------------------------------------------
+export default {
+  fetch: app.fetch,
+
+  // Cron Trigger: daily at 03:00 UTC (configured in wrangler.toml)
+  async scheduled(_event: ScheduledEvent, env: Env, _ctx: ExecutionContext): Promise<void> {
+    await enqueueFirstPage(env, todayISO());
+  },
+
+  // Queue consumer: max_batch_size = 1, so one message per invocation
+  async queue(
+    batch: MessageBatch<CrawlQueueMessage>,
+    env: Env,
+    _ctx: ExecutionContext,
+  ): Promise<void> {
+    for (const message of batch.messages) {
+      try {
+        await processPage(env, message.body.pageNumber, message.body.snapshotDate);
+        message.ack();
+      } catch (err) {
+        console.error(`[collector] Failed to process page ${message.body.pageNumber}:`, err);
+        message.retry();
+      }
+    }
+  },
+};

--- a/apps/meguru/collector/src/index.ts
+++ b/apps/meguru/collector/src/index.ts
@@ -26,8 +26,13 @@ app.post('/trigger', async (c) => {
   if (!c.env.TRIGGER_SECRET || provided !== c.env.TRIGGER_SECRET) {
     return c.json({ error: 'Unauthorized' }, 401);
   }
-  await enqueueFirstPage(c.env, todayISO());
-  return c.json({ ok: true, message: 'Collection triggered' });
+  try {
+    await enqueueFirstPage(c.env, todayISO());
+    return c.json({ ok: true, message: 'Collection triggered' });
+  } catch (err) {
+    console.error('[collector] /trigger error:', err);
+    return c.json({ error: 'Internal Server Error' }, 500);
+  }
 });
 
 app.get('/health', (c) => c.json({ ok: true }));
@@ -91,7 +96,6 @@ async function processPage(env: Env, pageNumber: number, snapshotDate: string): 
   if (extensions.length === PAGE_SIZE) {
     await env.CRAWL_QUEUE.send({ pageNumber: pageNumber + 1, snapshotDate });
   } else {
-    await invalidateRepositoryCaches(env);
     console.log(`[collector] Collection complete for ${snapshotDate}`);
   }
 }
@@ -104,7 +108,12 @@ export default {
 
   // Cron Trigger: daily at 03:00 UTC (configured in wrangler.toml)
   async scheduled(_event: ScheduledEvent, env: Env, _ctx: ExecutionContext): Promise<void> {
-    await enqueueFirstPage(env, todayISO());
+    try {
+      await enqueueFirstPage(env, todayISO());
+    } catch (err) {
+      console.error('[collector] scheduled error:', err);
+      throw err;
+    }
   },
 
   // Queue consumer: max_batch_size = 1, so one message per invocation

--- a/apps/meguru/collector/src/marketplace-api.ts
+++ b/apps/meguru/collector/src/marketplace-api.ts
@@ -117,8 +117,6 @@ export async function queryExtensions(options: QueryOptions): Promise<RawExtensi
         signal: controller.signal,
       });
 
-      clearTimeout(timeoutId);
-
       if (response.ok) {
         const data = (await response.json()) as QueryResponse;
         return data.results[0]?.extensions ?? [];
@@ -129,12 +127,13 @@ export async function queryExtensions(options: QueryOptions): Promise<RawExtensi
         `Marketplace API error ${response.status} (attempt ${attempt}/${MAX_RETRIES}), page ${options.pageNumber}`,
       );
     } catch (err) {
-      clearTimeout(timeoutId);
       lastError = err;
       console.warn(
         `Marketplace API request failed (attempt ${attempt}/${MAX_RETRIES}), page ${options.pageNumber}:`,
         err,
       );
+    } finally {
+      clearTimeout(timeoutId);
     }
 
     if (attempt < MAX_RETRIES) {

--- a/apps/meguru/collector/src/marketplace-api.ts
+++ b/apps/meguru/collector/src/marketplace-api.ts
@@ -84,6 +84,7 @@ interface QueryResponse {
 // ----------------------------------------------------------------
 
 const MAX_RETRIES = 5;
+const REQUEST_TIMEOUT_MS = 30_000;
 
 export async function queryExtensions(options: QueryOptions): Promise<RawExtension[]> {
   const body = {
@@ -100,38 +101,52 @@ export async function queryExtensions(options: QueryOptions): Promise<RawExtensi
     flags: FLAGS,
   };
 
-  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
-    const response = await fetch(MARKETPLACE_API_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: `application/json;api-version=${API_VERSION}`,
-      },
-      body: JSON.stringify(body),
-    });
+  let lastError: unknown;
 
-    if (response.ok) {
-      const data = (await response.json()) as QueryResponse;
-      return data.results[0]?.extensions ?? [];
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(MARKETPLACE_API_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: `application/json;api-version=${API_VERSION}`,
+        },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (response.ok) {
+        const data = (await response.json()) as QueryResponse;
+        return data.results[0]?.extensions ?? [];
+      }
+
+      lastError = new Error(`HTTP ${response.status}`);
+      console.warn(
+        `Marketplace API error ${response.status} (attempt ${attempt}/${MAX_RETRIES}), page ${options.pageNumber}`,
+      );
+    } catch (err) {
+      clearTimeout(timeoutId);
+      lastError = err;
+      console.warn(
+        `Marketplace API request failed (attempt ${attempt}/${MAX_RETRIES}), page ${options.pageNumber}:`,
+        err,
+      );
     }
 
-    const status = response.status;
-    console.warn(
-      `Marketplace API error ${status} (attempt ${attempt}/${MAX_RETRIES}), page ${options.pageNumber}`,
-    );
-
     if (attempt < MAX_RETRIES) {
-      // Exponential backoff: 1s, 2s, 4s, 8s (skipped on last attempt)
       const delay = 2 ** (attempt - 1) * 1000;
       await new Promise((resolve) => setTimeout(resolve, delay));
-    } else {
-      throw new Error(
-        `Marketplace API failed after ${MAX_RETRIES} retries on page ${options.pageNumber}: ${status}`,
-      );
     }
   }
 
-  return [];
+  throw new Error(
+    `Marketplace API failed after ${MAX_RETRIES} retries on page ${options.pageNumber}: ${lastError}`,
+  );
 }
 
 // ----------------------------------------------------------------

--- a/apps/meguru/collector/src/marketplace-api.ts
+++ b/apps/meguru/collector/src/marketplace-api.ts
@@ -54,7 +54,7 @@ interface Publisher {
   displayName: string;
   domain: string | null;
   isDomainVerified: boolean;
-  publisherFlags: string | null;
+  flags: string | null;
 }
 
 export interface RawExtension {
@@ -70,7 +70,6 @@ export interface RawExtension {
   publishedDate: string;
   releaseDate: string;
   lastUpdated: string;
-  pricing?: string | null;
 }
 
 interface QueryResponse {
@@ -189,7 +188,7 @@ export function toExtensionSnapshot(ext: RawExtension, snapshotDate: string): Ex
     publisher_display_name: ext.publisher.displayName,
     publisher_domain: ext.publisher.domain ?? null,
     publisher_domain_verified: ext.publisher.isDomainVerified ?? false,
-    publisher_verified: ext.publisher.publisherFlags === 'verified',
+    publisher_verified: ext.publisher.flags === 'verified',
 
     short_description: ext.shortDescription ?? null,
     categories: ext.categories ?? [],
@@ -212,7 +211,7 @@ export function toExtensionSnapshot(ext: RawExtension, snapshotDate: string): Ex
     target_platform: latestVersion?.targetPlatform ?? null,
     engine: getVersionProp(ext, 'Microsoft.VisualStudio.Code.Engine') ?? null,
     is_pre_release: getVersionProp(ext, 'Microsoft.VisualStudio.Code.PreRelease') === 'true',
-    pricing: ext.pricing ?? null,
+    pricing: getVersionProp(ext, 'Microsoft.VisualStudio.Services.Content.Pricing') ?? null,
     executes_code: getVersionProp(ext, 'Microsoft.VisualStudio.Code.ExecutesCode') === '1',
     extension_dependencies: splitProp(
       getVersionProp(ext, 'Microsoft.VisualStudio.Code.ExtensionDependencies'),

--- a/apps/meguru/collector/src/marketplace-api.ts
+++ b/apps/meguru/collector/src/marketplace-api.ts
@@ -1,0 +1,208 @@
+const MARKETPLACE_API_URL =
+  'https://marketplace.visualstudio.com/_apis/public/gallery/extensionquery';
+const API_VERSION = '7.2-preview.1';
+
+/**
+ * flags = 950 = 0x3B6
+ *   IncludeFiles (2)
+ *   IncludeCategoryAndTags (4)
+ *   IncludeVersionProperties (64)
+ *   ExcludeNonValidated (128)
+ *   IncludeStatistics (256)
+ *   IncludeLatestVersionOnly (512)
+ */
+const FLAGS = 950;
+
+export const SortBy = {
+  Installs: 4,
+  TrendingDaily: 7,
+  TrendingWeekly: 8,
+  TrendingMonthly: 9,
+} as const;
+export type SortByValue = (typeof SortBy)[keyof typeof SortBy];
+
+export interface QueryOptions {
+  sortBy: SortByValue;
+  pageSize: number;
+  pageNumber: number;
+}
+
+// ----------------------------------------------------------------
+// Raw API types (Gallery API response shape)
+// ----------------------------------------------------------------
+
+interface StatisticEntry {
+  statisticName: string;
+  value: number;
+}
+
+interface VersionProperty {
+  key: string;
+  value: string;
+}
+
+interface ExtensionVersion {
+  version: string;
+  lastUpdated: string;
+  targetPlatform?: string | null;
+  properties?: VersionProperty[];
+}
+
+interface Publisher {
+  publisherId: string;
+  publisherName: string;
+  displayName: string;
+  domain: string | null;
+  isDomainVerified: boolean;
+  publisherFlags: string | null;
+}
+
+export interface RawExtension {
+  extensionId: string;
+  extensionName: string;
+  displayName: string;
+  shortDescription: string;
+  publisher: Publisher;
+  versions: ExtensionVersion[];
+  statistics: StatisticEntry[];
+  categories: string[];
+  tags: string[];
+  publishedDate: string;
+  releaseDate: string;
+  lastUpdated: string;
+  pricing?: string | null;
+}
+
+interface QueryResponse {
+  results: Array<{
+    extensions: RawExtension[];
+  }>;
+}
+
+// ----------------------------------------------------------------
+// Query
+// ----------------------------------------------------------------
+
+const MAX_RETRIES = 5;
+
+export async function queryExtensions(options: QueryOptions): Promise<RawExtension[]> {
+  const body = {
+    filters: [
+      {
+        criteria: [{ filterType: 8, value: 'Microsoft.VisualStudio.Code' }],
+        pageNumber: options.pageNumber,
+        pageSize: options.pageSize,
+        sortBy: options.sortBy,
+        sortOrder: 0,
+      },
+    ],
+    assetTypes: [],
+    flags: FLAGS,
+  };
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    const response = await fetch(MARKETPLACE_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: `application/json;api-version=${API_VERSION}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (response.ok) {
+      const data = (await response.json()) as QueryResponse;
+      return data.results[0]?.extensions ?? [];
+    }
+
+    const status = response.status;
+    console.warn(
+      `Marketplace API error ${status} (attempt ${attempt}/${MAX_RETRIES}), page ${options.pageNumber}`,
+    );
+
+    if (attempt < MAX_RETRIES) {
+      // Exponential backoff: 1s, 2s, 4s, 8s (skipped on last attempt)
+      const delay = 2 ** (attempt - 1) * 1000;
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    } else {
+      throw new Error(
+        `Marketplace API failed after ${MAX_RETRIES} retries on page ${options.pageNumber}: ${status}`,
+      );
+    }
+  }
+
+  return [];
+}
+
+// ----------------------------------------------------------------
+// Stat helper
+// ----------------------------------------------------------------
+
+export function getStat(ext: RawExtension, name: string): number | null {
+  return ext.statistics?.find((s) => s.statisticName === name)?.value ?? null;
+}
+
+// ----------------------------------------------------------------
+// Mapping: RawExtension → ExtensionSnapshot
+// ----------------------------------------------------------------
+
+import type { ExtensionSnapshot } from '@meguru/types';
+
+function getVersionProp(ext: RawExtension, key: string): string | undefined {
+  return ext.versions[0]?.properties?.find((p) => p.key === key)?.value;
+}
+
+function splitProp(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function toExtensionSnapshot(ext: RawExtension, snapshotDate: string): ExtensionSnapshot {
+  const latestVersion = ext.versions[0];
+
+  return {
+    extension_id: ext.extensionId,
+    name: `${ext.publisher.publisherName}.${ext.extensionName}`,
+    display_name: ext.displayName,
+    snapshot_date: snapshotDate,
+
+    publisher_id: ext.publisher.publisherId,
+    publisher_name: ext.publisher.publisherName,
+    publisher_display_name: ext.publisher.displayName,
+    publisher_domain: ext.publisher.domain ?? null,
+    publisher_domain_verified: ext.publisher.isDomainVerified ?? false,
+    publisher_verified: ext.publisher.publisherFlags === 'verified',
+
+    short_description: ext.shortDescription ?? null,
+    categories: ext.categories ?? [],
+    tags: ext.tags ?? [],
+    published_date: ext.publishedDate,
+    release_date: ext.releaseDate ?? ext.publishedDate,
+    last_updated: ext.lastUpdated,
+
+    install_count: getStat(ext, 'install'),
+    download_count: getStat(ext, 'downloadCount'),
+    average_rating: getStat(ext, 'averagerating'),
+    rating_count: getStat(ext, 'ratingcount'),
+    weighted_rating: getStat(ext, 'weightedRating'),
+    trending_daily: getStat(ext, 'trendingdaily'),
+    trending_weekly: getStat(ext, 'trendingweekly'),
+    trending_monthly: getStat(ext, 'trendingmonthly'),
+    update_count: getStat(ext, 'updateCount'),
+
+    latest_version: latestVersion?.version ?? null,
+    target_platform: latestVersion?.targetPlatform ?? null,
+    engine: getVersionProp(ext, 'Microsoft.VisualStudio.Code.Engine') ?? null,
+    is_pre_release: getVersionProp(ext, 'Microsoft.VisualStudio.Code.PreRelease') === 'true',
+    pricing: ext.pricing ?? null,
+    executes_code: getVersionProp(ext, 'Microsoft.VisualStudio.Code.ExecutesCode') === '1',
+    extension_dependencies: splitProp(
+      getVersionProp(ext, 'Microsoft.VisualStudio.Code.ExtensionDependencies'),
+    ),
+    extension_pack: splitProp(getVersionProp(ext, 'Microsoft.VisualStudio.Code.ExtensionPack')),
+    extension_kind: splitProp(getVersionProp(ext, 'Microsoft.VisualStudio.Code.ExtensionKind')),
+  };
+}

--- a/apps/meguru/collector/tsconfig.json
+++ b/apps/meguru/collector/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@tsconfig/strictest",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext"],
+    "types": ["@cloudflare/workers-types"],
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", ".wrangler"]
+}

--- a/apps/meguru/collector/wrangler.toml
+++ b/apps/meguru/collector/wrangler.toml
@@ -1,0 +1,29 @@
+name = "meguru-collector"
+main = "src/index.ts"
+compatibility_date = "2024-11-01"
+compatibility_flags = ["nodejs_compat"]
+
+# Service Binding → repository worker
+[[services]]
+binding = "REPOSITORY"
+service = "meguru-repository"
+
+# Queue producer: collector enqueues next-page messages
+[[queues.producers]]
+binding = "CRAWL_QUEUE"
+queue = "meguru-crawl-queue"
+
+# Queue consumer: each message = 1 Marketplace page
+[[queues.consumers]]
+queue = "meguru-crawl-queue"
+max_batch_size = 1
+max_batch_timeout = 0
+max_retries = 2
+dead_letter_queue = "meguru-crawl-dlq"
+
+# Cron Trigger: daily at 03:00 UTC
+[triggers]
+crons = ["0 3 * * *"]
+
+[dev]
+port = 8788

--- a/apps/meguru/collector/wrangler.toml
+++ b/apps/meguru/collector/wrangler.toml
@@ -3,6 +3,11 @@ main = "src/index.ts"
 compatibility_date = "2024-11-01"
 compatibility_flags = ["nodejs_compat"]
 
+# Set via: wrangler secret put TRIGGER_SECRET
+# Used to authenticate POST /trigger calls
+# Set via: wrangler secret put INTERNAL_SECRET (same value as repository)
+# Passed to repository /write and /invalidate as X-Internal-Secret header
+
 # Service Binding → repository worker
 [[services]]
 binding = "REPOSITORY"

--- a/apps/meguru/collector/wrangler.toml
+++ b/apps/meguru/collector/wrangler.toml
@@ -23,7 +23,7 @@ queue = "meguru-crawl-queue"
 queue = "meguru-crawl-queue"
 max_batch_size = 1
 max_batch_timeout = 0
-max_retries = 0
+max_retries = 5
 dead_letter_queue = "meguru-crawl-dlq"
 
 # Cron Trigger: daily at 03:00 UTC

--- a/apps/meguru/collector/wrangler.toml
+++ b/apps/meguru/collector/wrangler.toml
@@ -23,7 +23,7 @@ queue = "meguru-crawl-queue"
 queue = "meguru-crawl-queue"
 max_batch_size = 1
 max_batch_timeout = 0
-max_retries = 2
+max_retries = 0
 dead_letter_queue = "meguru-crawl-dlq"
 
 # Cron Trigger: daily at 03:00 UTC

--- a/apps/meguru/dashboard/package.json
+++ b/apps/meguru/dashboard/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@meguru/dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check --write .",
+    "lint:check": "biome check .",
+    "clean": "rm -rf .wrangler node_modules"
+  },
+  "dependencies": {
+    "@meguru/types": "workspace:*",
+    "hono": "^4.7.5"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@cloudflare/workers-types": "^4.20250409.0",
+    "typescript": "catalog:",
+    "wrangler": "^3.114.0"
+  }
+}

--- a/apps/meguru/dashboard/src/index.tsx
+++ b/apps/meguru/dashboard/src/index.tsx
@@ -5,6 +5,17 @@ interface Env {
   REPOSITORY: Fetcher;
 }
 
+const VALID_PERIODS = new Set(['daily', 'weekly', 'monthly'] as const);
+type Period = 'daily' | 'weekly' | 'monthly';
+
+function normalizePeriod(value: string | undefined): Period {
+  return VALID_PERIODS.has(value as Period) ? (value as Period) : 'weekly';
+}
+
+function formatNumber(n: number): string {
+  return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
 const app = new Hono<{ Bindings: Env }>();
 
 // ----------------------------------------------------------------
@@ -63,7 +74,7 @@ function Layout({ title, children }: { title: string; children: unknown }) {
 // ----------------------------------------------------------------
 
 app.get('/', async (c) => {
-  const period = (c.req.query('period') ?? 'weekly') as 'daily' | 'weekly' | 'monthly';
+  const period = normalizePeriod(c.req.query('period'));
   const limit = 50;
 
   let items: TrendingItem[] = [];
@@ -133,7 +144,9 @@ app.get('/', async (c) => {
                     </span>
                   ))}
                 </td>
-                <td class="num">{item.install_count?.toLocaleString() ?? '—'}</td>
+                <td class="num">
+                  {item.install_count != null ? formatNumber(item.install_count) : '—'}
+                </td>
                 <td class="num">
                   {period === 'daily'
                     ? (item.trending_daily?.toFixed(2) ?? '—')
@@ -200,8 +213,8 @@ app.get('/categories', async (c) => {
               <tr key={cat.category}>
                 <td class="rank">{i + 1}</td>
                 <td>{cat.category}</td>
-                <td class="num">{cat.total_extensions.toLocaleString()}</td>
-                <td class="num">{cat.total_installs.toLocaleString()}</td>
+                <td class="num">{formatNumber(cat.total_extensions)}</td>
+                <td class="num">{formatNumber(cat.total_installs)}</td>
               </tr>
             ))}
           </tbody>

--- a/apps/meguru/dashboard/src/index.tsx
+++ b/apps/meguru/dashboard/src/index.tsx
@@ -1,0 +1,190 @@
+import type { CategorySummary, TrendingItem } from '@meguru/types';
+import { Hono } from 'hono';
+
+interface Env {
+  REPOSITORY: Fetcher;
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+// ----------------------------------------------------------------
+// Layout
+// ----------------------------------------------------------------
+
+function Layout({ title, children }: { title: string; children: unknown }) {
+  return (
+    <html lang="ja">
+      <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>{title} — Meguru</title>
+        <style>{`
+          * { box-sizing: border-box; margin: 0; padding: 0; }
+          body { font-family: system-ui, sans-serif; background: #0d1117; color: #e6edf3; line-height: 1.5; }
+          header { background: #161b22; border-bottom: 1px solid #30363d; padding: 12px 24px; display: flex; align-items: center; gap: 16px; }
+          header h1 { font-size: 1.2rem; font-weight: 600; color: #58a6ff; }
+          nav a { color: #8b949e; text-decoration: none; padding: 4px 8px; border-radius: 6px; }
+          nav a:hover { color: #e6edf3; background: #21262d; }
+          main { max-width: 1200px; margin: 24px auto; padding: 0 24px; }
+          h2 { font-size: 1.4rem; font-weight: 600; margin-bottom: 16px; color: #e6edf3; }
+          table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+          thead th { text-align: left; padding: 8px 12px; border-bottom: 1px solid #30363d; color: #8b949e; font-weight: 500; }
+          tbody tr { border-bottom: 1px solid #21262d; }
+          tbody tr:hover { background: #161b22; }
+          tbody td { padding: 10px 12px; }
+          .badge { display: inline-block; padding: 2px 8px; border-radius: 12px; font-size: 0.75rem; background: #21262d; color: #8b949e; margin: 1px; }
+          .num { text-align: right; font-variant-numeric: tabular-nums; }
+          .rank { color: #8b949e; font-size: 0.85rem; }
+          .ext-name { font-weight: 500; color: #58a6ff; }
+          .ext-pub { color: #8b949e; font-size: 0.85rem; }
+          .section { margin-bottom: 40px; }
+          .tab-bar { display: flex; gap: 8px; margin-bottom: 20px; }
+          .tab-bar a { padding: 6px 16px; border-radius: 6px; text-decoration: none; color: #8b949e; background: #21262d; }
+          .tab-bar a.active { background: #1f6feb; color: #fff; }
+          .stars { color: #f9c513; }
+        `}</style>
+      </head>
+      <body>
+        <header>
+          <h1>🔭 Meguru</h1>
+          <nav>
+            <a href="/">Trending</a>
+            <a href="/categories">Categories</a>
+          </nav>
+        </header>
+        <main>{children}</main>
+      </body>
+    </html>
+  );
+}
+
+// ----------------------------------------------------------------
+// Trending page
+// ----------------------------------------------------------------
+
+app.get('/', async (c) => {
+  const period = (c.req.query('period') ?? 'weekly') as 'daily' | 'weekly' | 'monthly';
+  const limit = 50;
+
+  const res = await c.env.REPOSITORY.fetch(
+    `http://internal/trending?period=${period}&limit=${limit}`,
+  );
+  const items = (await res.json()) as TrendingItem[];
+
+  const tabs = [
+    { label: 'Weekly', value: 'weekly' },
+    { label: 'Daily', value: 'daily' },
+    { label: 'Monthly', value: 'monthly' },
+  ];
+
+  return c.html(
+    <Layout title="Trending">
+      <div class="section">
+        <h2>Trending Extensions</h2>
+        <div class="tab-bar">
+          {tabs.map((t) => (
+            <a
+              key={t.value}
+              href={`/?period=${t.value}`}
+              class={period === t.value ? 'active' : ''}
+            >
+              {t.label}
+            </a>
+          ))}
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Extension</th>
+              <th>Categories</th>
+              <th class="num">Installs</th>
+              <th class="num">Trending ({period})</th>
+              <th class="num">Rating</th>
+            </tr>
+          </thead>
+          <tbody>
+            {items.map((item, i) => (
+              <tr key={item.extension_id}>
+                <td class="rank">{i + 1}</td>
+                <td>
+                  <div class="ext-name">{item.display_name}</div>
+                  <div class="ext-pub">{item.publisher_name}</div>
+                </td>
+                <td>
+                  {item.categories.slice(0, 3).map((cat) => (
+                    <span key={cat} class="badge">
+                      {cat}
+                    </span>
+                  ))}
+                </td>
+                <td class="num">{item.install_count?.toLocaleString() ?? '—'}</td>
+                <td class="num">
+                  {period === 'daily'
+                    ? item.trending_daily?.toFixed(2)
+                    : period === 'monthly'
+                      ? item.trending_monthly?.toFixed(2)
+                      : (item.trending_weekly?.toFixed(2) ?? '—')}
+                </td>
+                <td class="num">
+                  {item.average_rating != null ? (
+                    <span>
+                      <span class="stars">★</span> {item.average_rating.toFixed(1)}
+                    </span>
+                  ) : (
+                    '—'
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Layout>,
+  );
+});
+
+// ----------------------------------------------------------------
+// Categories page
+// ----------------------------------------------------------------
+
+app.get('/categories', async (c) => {
+  const res = await c.env.REPOSITORY.fetch('http://internal/categories');
+  const categories = (await res.json()) as CategorySummary[];
+
+  return c.html(
+    <Layout title="Categories">
+      <div class="section">
+        <h2>Categories</h2>
+        <table>
+          <thead>
+            <tr>
+              <th>#</th>
+              <th>Category</th>
+              <th class="num">Extensions</th>
+              <th class="num">Total Installs</th>
+            </tr>
+          </thead>
+          <tbody>
+            {categories.map((cat, i) => (
+              <tr key={cat.category}>
+                <td class="rank">{i + 1}</td>
+                <td>{cat.category}</td>
+                <td class="num">{cat.total_extensions.toLocaleString()}</td>
+                <td class="num">{cat.total_installs.toLocaleString()}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </Layout>,
+  );
+});
+
+// ----------------------------------------------------------------
+// Health check
+// ----------------------------------------------------------------
+
+app.get('/health', (c) => c.json({ ok: true }));
+
+export default app;

--- a/apps/meguru/dashboard/src/index.tsx
+++ b/apps/meguru/dashboard/src/index.tsx
@@ -66,10 +66,25 @@ app.get('/', async (c) => {
   const period = (c.req.query('period') ?? 'weekly') as 'daily' | 'weekly' | 'monthly';
   const limit = 50;
 
-  const res = await c.env.REPOSITORY.fetch(
-    `http://internal/trending?period=${period}&limit=${limit}`,
-  );
-  const items = (await res.json()) as TrendingItem[];
+  let items: TrendingItem[] = [];
+  try {
+    const res = await c.env.REPOSITORY.fetch(
+      `http://internal/trending?period=${period}&limit=${limit}`,
+    );
+    if (!res.ok) throw new Error(`Repository error ${res.status}`);
+    items = (await res.json()) as TrendingItem[];
+  } catch (err) {
+    console.error('[dashboard] / fetch error:', err);
+    return c.html(
+      <Layout title="Trending">
+        <div class="section">
+          <h2>Trending Extensions</h2>
+          <p style="color:#f85149">Failed to load data. Please try again later.</p>
+        </div>
+      </Layout>,
+      500,
+    );
+  }
 
   const tabs = [
     { label: 'Weekly', value: 'weekly' },
@@ -121,9 +136,9 @@ app.get('/', async (c) => {
                 <td class="num">{item.install_count?.toLocaleString() ?? '—'}</td>
                 <td class="num">
                   {period === 'daily'
-                    ? item.trending_daily?.toFixed(2)
+                    ? (item.trending_daily?.toFixed(2) ?? '—')
                     : period === 'monthly'
-                      ? item.trending_monthly?.toFixed(2)
+                      ? (item.trending_monthly?.toFixed(2) ?? '—')
                       : (item.trending_weekly?.toFixed(2) ?? '—')}
                 </td>
                 <td class="num">
@@ -149,8 +164,23 @@ app.get('/', async (c) => {
 // ----------------------------------------------------------------
 
 app.get('/categories', async (c) => {
-  const res = await c.env.REPOSITORY.fetch('http://internal/categories');
-  const categories = (await res.json()) as CategorySummary[];
+  let categories: CategorySummary[] = [];
+  try {
+    const res = await c.env.REPOSITORY.fetch('http://internal/categories');
+    if (!res.ok) throw new Error(`Repository error ${res.status}`);
+    categories = (await res.json()) as CategorySummary[];
+  } catch (err) {
+    console.error('[dashboard] /categories fetch error:', err);
+    return c.html(
+      <Layout title="Categories">
+        <div class="section">
+          <h2>Categories</h2>
+          <p style="color:#f85149">Failed to load data. Please try again later.</p>
+        </div>
+      </Layout>,
+      500,
+    );
+  }
 
   return c.html(
     <Layout title="Categories">

--- a/apps/meguru/dashboard/tsconfig.json
+++ b/apps/meguru/dashboard/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@tsconfig/strictest",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext"],
+    "types": ["@cloudflare/workers-types"],
+    "jsx": "react-jsx",
+    "jsxImportSource": "hono/jsx",
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", ".wrangler"]
+}

--- a/apps/meguru/dashboard/wrangler.toml
+++ b/apps/meguru/dashboard/wrangler.toml
@@ -1,0 +1,12 @@
+name = "meguru-dashboard"
+main = "src/index.tsx"
+compatibility_date = "2024-11-01"
+compatibility_flags = ["nodejs_compat"]
+
+# Service Binding → repository worker
+[[services]]
+binding = "REPOSITORY"
+service = "meguru-repository"
+
+[dev]
+port = 8790

--- a/apps/meguru/gateway/package.json
+++ b/apps/meguru/gateway/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@meguru/gateway",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check --write .",
+    "lint:check": "biome check .",
+    "clean": "rm -rf .wrangler node_modules"
+  },
+  "dependencies": {
+    "@meguru/types": "workspace:*",
+    "hono": "^4.7.5"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@cloudflare/workers-types": "^4.20250409.0",
+    "typescript": "catalog:",
+    "wrangler": "^3.114.0"
+  }
+}

--- a/apps/meguru/gateway/src/index.ts
+++ b/apps/meguru/gateway/src/index.ts
@@ -21,52 +21,74 @@ function repo(env: Env, path: string): Promise<Response> {
 // GET /api/trending?period=weekly&limit=20
 // ----------------------------------------------------------------
 app.get('/api/trending', async (c) => {
-  const period = c.req.query('period') ?? 'weekly';
-  const limit = c.req.query('limit') ?? '20';
-  const res = await repo(c.env, `/trending?period=${period}&limit=${limit}`);
-  return new Response(res.body, {
-    status: res.status,
-    headers: { 'Content-Type': 'application/json' },
-  });
+  try {
+    const qs = new URLSearchParams({
+      period: c.req.query('period') ?? 'weekly',
+      limit: c.req.query('limit') ?? '20',
+    }).toString();
+    const res = await repo(c.env, `/trending?${qs}`);
+    return new Response(res.body, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('[gateway] /api/trending error:', err);
+    return c.json({ error: 'Internal Server Error' }, 500);
+  }
 });
 
 // ----------------------------------------------------------------
 // GET /api/growth?id=<extensionId>&days=30
 // ----------------------------------------------------------------
 app.get('/api/growth', async (c) => {
-  const id = c.req.query('id');
-  if (!id) return c.json({ error: 'id is required' }, 400);
-  const days = c.req.query('days') ?? '30';
-  const res = await repo(c.env, `/growth/${encodeURIComponent(id)}?days=${days}`);
-  return new Response(res.body, {
-    status: res.status,
-    headers: { 'Content-Type': 'application/json' },
-  });
+  try {
+    const id = c.req.query('id');
+    if (!id) return c.json({ error: 'id is required' }, 400);
+    const qs = new URLSearchParams({ days: c.req.query('days') ?? '30' }).toString();
+    const res = await repo(c.env, `/growth/${encodeURIComponent(id)}?${qs}`);
+    return new Response(res.body, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('[gateway] /api/growth error:', err);
+    return c.json({ error: 'Internal Server Error' }, 500);
+  }
 });
 
 // ----------------------------------------------------------------
 // GET /api/categories
 // ----------------------------------------------------------------
 app.get('/api/categories', async (c) => {
-  const res = await repo(c.env, '/categories');
-  return new Response(res.body, {
-    status: res.status,
-    headers: { 'Content-Type': 'application/json' },
-  });
+  try {
+    const res = await repo(c.env, '/categories');
+    return new Response(res.body, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('[gateway] /api/categories error:', err);
+    return c.json({ error: 'Internal Server Error' }, 500);
+  }
 });
 
 // ----------------------------------------------------------------
 // GET /api/search?q=<keyword>&limit=50
 // ----------------------------------------------------------------
 app.get('/api/search', async (c) => {
-  const q = c.req.query('q');
-  if (!q) return c.json({ error: 'q is required' }, 400);
-  const limit = c.req.query('limit') ?? '50';
-  const res = await repo(c.env, `/search?q=${encodeURIComponent(q)}&limit=${limit}`);
-  return new Response(res.body, {
-    status: res.status,
-    headers: { 'Content-Type': 'application/json' },
-  });
+  try {
+    const q = c.req.query('q');
+    if (!q) return c.json({ error: 'q is required' }, 400);
+    const qs = new URLSearchParams({ q, limit: c.req.query('limit') ?? '50' }).toString();
+    const res = await repo(c.env, `/search?${qs}`);
+    return new Response(res.body, {
+      status: res.status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (err) {
+    console.error('[gateway] /api/search error:', err);
+    return c.json({ error: 'Internal Server Error' }, 500);
+  }
 });
 
 // ----------------------------------------------------------------

--- a/apps/meguru/gateway/src/index.ts
+++ b/apps/meguru/gateway/src/index.ts
@@ -11,10 +11,15 @@ const app = new Hono<{ Bindings: Env }>();
 app.use('/api/*', cors());
 
 // ----------------------------------------------------------------
-// Helper: forward to repository via Service Binding
+// Helpers
 // ----------------------------------------------------------------
 function repo(env: Env, path: string): Promise<Response> {
   return env.REPOSITORY.fetch(`http://internal${path}`);
+}
+
+const VALID_PERIODS = new Set(['daily', 'weekly', 'monthly']);
+function normalizePeriod(value: string | undefined): string {
+  return VALID_PERIODS.has(value ?? '') ? (value as string) : 'weekly';
 }
 
 // ----------------------------------------------------------------
@@ -23,7 +28,7 @@ function repo(env: Env, path: string): Promise<Response> {
 app.get('/api/trending', async (c) => {
   try {
     const qs = new URLSearchParams({
-      period: c.req.query('period') ?? 'weekly',
+      period: normalizePeriod(c.req.query('period')),
       limit: c.req.query('limit') ?? '20',
     }).toString();
     const res = await repo(c.env, `/trending?${qs}`);

--- a/apps/meguru/gateway/src/index.ts
+++ b/apps/meguru/gateway/src/index.ts
@@ -1,0 +1,77 @@
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+
+interface Env {
+  REPOSITORY: Fetcher;
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+// Allow all origins (CLI + browser)
+app.use('/api/*', cors());
+
+// ----------------------------------------------------------------
+// Helper: forward to repository via Service Binding
+// ----------------------------------------------------------------
+function repo(env: Env, path: string): Promise<Response> {
+  return env.REPOSITORY.fetch(`http://internal${path}`);
+}
+
+// ----------------------------------------------------------------
+// GET /api/trending?period=weekly&limit=20
+// ----------------------------------------------------------------
+app.get('/api/trending', async (c) => {
+  const period = c.req.query('period') ?? 'weekly';
+  const limit = c.req.query('limit') ?? '20';
+  const res = await repo(c.env, `/trending?period=${period}&limit=${limit}`);
+  return new Response(res.body, {
+    status: res.status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+});
+
+// ----------------------------------------------------------------
+// GET /api/growth?id=<extensionId>&days=30
+// ----------------------------------------------------------------
+app.get('/api/growth', async (c) => {
+  const id = c.req.query('id');
+  if (!id) return c.json({ error: 'id is required' }, 400);
+  const days = c.req.query('days') ?? '30';
+  const res = await repo(c.env, `/growth/${encodeURIComponent(id)}?days=${days}`);
+  return new Response(res.body, {
+    status: res.status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+});
+
+// ----------------------------------------------------------------
+// GET /api/categories
+// ----------------------------------------------------------------
+app.get('/api/categories', async (c) => {
+  const res = await repo(c.env, '/categories');
+  return new Response(res.body, {
+    status: res.status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+});
+
+// ----------------------------------------------------------------
+// GET /api/search?q=<keyword>&limit=50
+// ----------------------------------------------------------------
+app.get('/api/search', async (c) => {
+  const q = c.req.query('q');
+  if (!q) return c.json({ error: 'q is required' }, 400);
+  const limit = c.req.query('limit') ?? '50';
+  const res = await repo(c.env, `/search?q=${encodeURIComponent(q)}&limit=${limit}`);
+  return new Response(res.body, {
+    status: res.status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+});
+
+// ----------------------------------------------------------------
+// GET /health
+// ----------------------------------------------------------------
+app.get('/health', (c) => c.json({ ok: true }));
+
+export default app;

--- a/apps/meguru/gateway/tsconfig.json
+++ b/apps/meguru/gateway/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@tsconfig/strictest",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext"],
+    "types": ["@cloudflare/workers-types"],
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", ".wrangler"]
+}

--- a/apps/meguru/gateway/wrangler.toml
+++ b/apps/meguru/gateway/wrangler.toml
@@ -1,0 +1,12 @@
+name = "meguru-gateway"
+main = "src/index.ts"
+compatibility_date = "2024-11-01"
+compatibility_flags = ["nodejs_compat"]
+
+# Service Binding → repository worker
+[[services]]
+binding = "REPOSITORY"
+service = "meguru-repository"
+
+[dev]
+port = 8789

--- a/apps/meguru/repository/package.json
+++ b/apps/meguru/repository/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@meguru/repository",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit",
+    "lint": "biome check --write .",
+    "lint:check": "biome check .",
+    "clean": "rm -rf .wrangler node_modules"
+  },
+  "dependencies": {
+    "@meguru/types": "workspace:*",
+    "hono": "^4.7.5"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "catalog:",
+    "@cloudflare/workers-types": "^4.20250409.0",
+    "typescript": "catalog:",
+    "wrangler": "^3.114.0"
+  }
+}

--- a/apps/meguru/repository/src/aggregate.ts
+++ b/apps/meguru/repository/src/aggregate.ts
@@ -70,11 +70,16 @@ export async function getGrowth(
   extensionId: string,
   days: number,
 ): Promise<GrowthPoint[]> {
-  const cacheKey = `growth/${extensionId}.json`;
-  const cached = await readAggregated<GrowthPoint[]>(bucket, cacheKey);
-  if (cached) return cached.slice(-days);
+  const allDates = await listSnapshotDates(bucket);
+  const latestDate = allDates[0];
+  if (!latestDate) return [];
 
-  const dates = (await listSnapshotDates(bucket)).slice(0, days);
+  // Cache key includes latestDate + days window to avoid stale results
+  const cacheKey = `growth/${latestDate}/${days}/${extensionId}.json`;
+  const cached = await readAggregated<GrowthPoint[]>(bucket, cacheKey);
+  if (cached) return cached;
+
+  const dates = allDates.slice(0, days);
   const points: GrowthPoint[] = [];
 
   for (const date of dates) {
@@ -91,6 +96,7 @@ export async function getGrowth(
   }
 
   points.sort((a, b) => a.date.localeCompare(b.date));
+  await writeAggregated(bucket, cacheKey, points);
   return points;
 }
 

--- a/apps/meguru/repository/src/aggregate.ts
+++ b/apps/meguru/repository/src/aggregate.ts
@@ -53,8 +53,9 @@ export async function getTrending(
 
   items.sort((a, b) => (b[sortField] ?? 0) - (a[sortField] ?? 0));
 
-  await writeAggregated(bucket, cacheKey, items);
-  return items.slice(0, limit);
+  const top = items.slice(0, 500);
+  await writeAggregated(bucket, cacheKey, top);
+  return top.slice(0, limit);
 }
 
 // ----------------------------------------------------------------
@@ -186,4 +187,17 @@ export async function invalidateCaches(bucket: R2Bucket): Promise<void> {
     'vscode-marketplace/aggregated/categories.json',
   ];
   await Promise.all(keys.map((k) => bucket.delete(k)));
+
+  // Delete growth caches (prefixed with growth/)
+  const growthPrefix = 'vscode-marketplace/aggregated/growth/';
+  let cursor: string | undefined;
+  do {
+    const listed = await bucket.list(
+      cursor ? { prefix: growthPrefix, cursor } : { prefix: growthPrefix },
+    );
+    if (listed.objects.length > 0) {
+      await Promise.all(listed.objects.map((obj) => bucket.delete(obj.key)));
+    }
+    cursor = listed.truncated ? listed.cursor : undefined;
+  } while (cursor);
 }

--- a/apps/meguru/repository/src/aggregate.ts
+++ b/apps/meguru/repository/src/aggregate.ts
@@ -1,0 +1,183 @@
+import type { CategorySummary, GrowthPoint, TrendingItem } from '@meguru/types';
+import {
+  iterateSnapshotRecords,
+  listSnapshotDates,
+  readAggregated,
+  writeAggregated,
+} from './r2.js';
+
+// ----------------------------------------------------------------
+// Trending
+// ----------------------------------------------------------------
+
+/**
+ * Compute trending extensions from the latest snapshot.
+ * Results are cached in R2 as aggregated/trending-<period>.json.
+ */
+export async function getTrending(
+  bucket: R2Bucket,
+  period: 'daily' | 'weekly' | 'monthly',
+  limit: number,
+): Promise<TrendingItem[]> {
+  const cacheKey = `trending-${period}.json`;
+  const cached = await readAggregated<TrendingItem[]>(bucket, cacheKey);
+  if (cached) return cached.slice(0, limit);
+
+  const dates = await listSnapshotDates(bucket);
+  const date = dates[0];
+  if (!date) return [];
+
+  const items: TrendingItem[] = [];
+
+  for await (const record of iterateSnapshotRecords(bucket, date)) {
+    items.push({
+      extension_id: record.extension_id,
+      name: record.name,
+      display_name: record.display_name,
+      publisher_name: record.publisher_name,
+      install_count: record.install_count,
+      trending_weekly: record.trending_weekly,
+      trending_daily: record.trending_daily,
+      trending_monthly: record.trending_monthly,
+      average_rating: record.average_rating,
+      categories: record.categories,
+    });
+  }
+
+  const sortField =
+    period === 'daily'
+      ? 'trending_daily'
+      : period === 'monthly'
+        ? 'trending_monthly'
+        : 'trending_weekly';
+
+  items.sort((a, b) => (b[sortField] ?? 0) - (a[sortField] ?? 0));
+
+  await writeAggregated(bucket, cacheKey, items);
+  return items.slice(0, limit);
+}
+
+// ----------------------------------------------------------------
+// Growth
+// ----------------------------------------------------------------
+
+/**
+ * Growth history for a single extension across recent dates.
+ * Checks per-extension cache first.
+ */
+export async function getGrowth(
+  bucket: R2Bucket,
+  extensionId: string,
+  days: number,
+): Promise<GrowthPoint[]> {
+  const cacheKey = `growth/${extensionId}.json`;
+  const cached = await readAggregated<GrowthPoint[]>(bucket, cacheKey);
+  if (cached) return cached.slice(-days);
+
+  const dates = (await listSnapshotDates(bucket)).slice(0, days);
+  const points: GrowthPoint[] = [];
+
+  for (const date of dates) {
+    for await (const record of iterateSnapshotRecords(bucket, date)) {
+      if (record.extension_id === extensionId) {
+        points.push({
+          date,
+          install_count: record.install_count,
+          trending_weekly: record.trending_weekly,
+        });
+        break;
+      }
+    }
+  }
+
+  points.sort((a, b) => a.date.localeCompare(b.date));
+  return points;
+}
+
+// ----------------------------------------------------------------
+// Categories
+// ----------------------------------------------------------------
+
+export async function getCategories(bucket: R2Bucket): Promise<CategorySummary[]> {
+  const cacheKey = 'categories.json';
+  const cached = await readAggregated<CategorySummary[]>(bucket, cacheKey);
+  if (cached) return cached;
+
+  const dates = await listSnapshotDates(bucket);
+  const date = dates[0];
+  if (!date) return [];
+
+  const categoryMap = new Map<string, { count: number; installs: number }>();
+
+  for await (const record of iterateSnapshotRecords(bucket, date)) {
+    for (const category of record.categories) {
+      const existing = categoryMap.get(category) ?? { count: 0, installs: 0 };
+      existing.count++;
+      existing.installs += record.install_count ?? 0;
+      categoryMap.set(category, existing);
+    }
+  }
+
+  const result: CategorySummary[] = [...categoryMap.entries()]
+    .map(([category, { count, installs }]) => ({
+      category,
+      total_extensions: count,
+      total_installs: installs,
+    }))
+    .sort((a, b) => b.total_installs - a.total_installs);
+
+  await writeAggregated(bucket, cacheKey, result);
+  return result;
+}
+
+// ----------------------------------------------------------------
+// Search
+// ----------------------------------------------------------------
+
+export async function searchExtensions(bucket: R2Bucket, query: string, maxResults = 50) {
+  const dates = await listSnapshotDates(bucket);
+  const date = dates[0];
+  if (!date) return [];
+
+  const lowerQuery = query.toLowerCase();
+  const results = [];
+
+  for await (const record of iterateSnapshotRecords(bucket, date)) {
+    const matches =
+      record.name.toLowerCase().includes(lowerQuery) ||
+      record.display_name.toLowerCase().includes(lowerQuery) ||
+      record.short_description?.toLowerCase().includes(lowerQuery) ||
+      record.categories.some((c) => c.toLowerCase().includes(lowerQuery)) ||
+      record.tags.some((t) => t.toLowerCase().includes(lowerQuery));
+
+    if (matches) {
+      results.push({
+        extension_id: record.extension_id,
+        name: record.name,
+        display_name: record.display_name,
+        publisher_name: record.publisher_name,
+        short_description: record.short_description,
+        install_count: record.install_count,
+        average_rating: record.average_rating,
+        categories: record.categories,
+      });
+      if (results.length >= maxResults) break;
+    }
+  }
+
+  return results;
+}
+
+// ----------------------------------------------------------------
+// Invalidate aggregated caches (after collection completes)
+// ----------------------------------------------------------------
+
+export async function invalidateCaches(bucket: R2Bucket): Promise<void> {
+  const keys = [
+    'vscode-marketplace/aggregated/trending-daily.json',
+    'vscode-marketplace/aggregated/trending-weekly.json',
+    'vscode-marketplace/aggregated/trending-monthly.json',
+    'vscode-marketplace/aggregated/categories.json',
+  ];
+  await Promise.all(keys.map((k) => bucket.delete(k)));
+}

--- a/apps/meguru/repository/src/index.ts
+++ b/apps/meguru/repository/src/index.ts
@@ -11,73 +11,138 @@ import { writeSnapshotChunk } from './r2.js';
 
 interface Env {
   VSCODE_MARKETPLACE_BUCKET: R2Bucket;
+  INTERNAL_SECRET: string;
+}
+
+/** Parse a query param as a bounded integer. Falls back to `fallback` on NaN/out-of-range. */
+function parseBoundedInt(
+  value: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(min, Math.min(Math.trunc(n), max));
+}
+
+/** Guard state-changing endpoints with a shared secret (set via `wrangler secret put INTERNAL_SECRET`). */
+function verifyInternalSecret(
+  c: {
+    req: { header: (k: string) => string | undefined };
+    json: (data: unknown, status?: number) => Response;
+  },
+  env: Env,
+): Response | null {
+  const provided = c.req.header('X-Internal-Secret');
+  if (!env.INTERNAL_SECRET || provided !== env.INTERNAL_SECRET) {
+    return c.json({ error: 'Unauthorized' }, 401) as Response;
+  }
+  return null;
 }
 
 const app = new Hono<{ Bindings: Env }>();
 
 // ----------------------------------------------------------------
 // POST /write  — collector writes snapshot batches here
-// Body: { date: string; records: ExtensionSnapshot[] }
+// Body: { date: string; chunkId: string; records: ExtensionSnapshot[] }
 // ----------------------------------------------------------------
 app.post('/write', async (c) => {
-  const { date, records } = await c.req.json<{
-    date: string;
-    records: ExtensionSnapshot[];
-  }>();
+  const authError = verifyInternalSecret(c, c.env);
+  if (authError) return authError;
 
-  if (!date || !Array.isArray(records)) {
-    return c.json({ error: 'date and records are required' }, 400);
+  try {
+    const { date, chunkId, records } = await c.req.json<{
+      date: string;
+      chunkId: string;
+      records: ExtensionSnapshot[];
+    }>();
+
+    if (!date || !chunkId || !Array.isArray(records)) {
+      return c.json({ error: 'date, chunkId and records are required' }, 400);
+    }
+
+    await writeSnapshotChunk(c.env.VSCODE_MARKETPLACE_BUCKET, date, chunkId, records);
+    return c.json({ ok: true, count: records.length });
+  } catch (err) {
+    console.error('[repository] /write error:', err);
+    return c.json({ error: 'Internal Server Error' }, 500);
   }
-
-  await writeSnapshotChunk(c.env.VSCODE_MARKETPLACE_BUCKET, date, records);
-  return c.json({ ok: true, count: records.length });
 });
 
 // ----------------------------------------------------------------
 // POST /invalidate  — called after collection completes
 // ----------------------------------------------------------------
 app.post('/invalidate', async (c) => {
-  await invalidateCaches(c.env.VSCODE_MARKETPLACE_BUCKET);
-  return c.json({ ok: true });
+  const authError = verifyInternalSecret(c, c.env);
+  if (authError) return authError;
+
+  try {
+    await invalidateCaches(c.env.VSCODE_MARKETPLACE_BUCKET);
+    return c.json({ ok: true });
+  } catch (err) {
+    console.error('[repository] /invalidate error:', err);
+    return c.json({ error: 'Internal Server Error' }, 500);
+  }
 });
 
 // ----------------------------------------------------------------
 // GET /trending?period=weekly&limit=50
 // ----------------------------------------------------------------
 app.get('/trending', async (c) => {
-  const period = (c.req.query('period') ?? 'weekly') as 'daily' | 'weekly' | 'monthly';
-  const limit = Math.min(Number(c.req.query('limit') ?? '50'), 500);
-  const result = await getTrending(c.env.VSCODE_MARKETPLACE_BUCKET, period, limit);
-  return c.json(result);
+  try {
+    const period = (c.req.query('period') ?? 'weekly') as 'daily' | 'weekly' | 'monthly';
+    const limit = parseBoundedInt(c.req.query('limit'), 50, 1, 500);
+    const result = await getTrending(c.env.VSCODE_MARKETPLACE_BUCKET, period, limit);
+    return c.json(result);
+  } catch (err) {
+    console.error('[repository] /trending error:', err);
+    return c.json({ error: 'Internal Server Error' }, 500);
+  }
 });
 
 // ----------------------------------------------------------------
 // GET /growth/:extensionId?days=30
 // ----------------------------------------------------------------
 app.get('/growth/:extensionId', async (c) => {
-  const extensionId = c.req.param('extensionId');
-  const days = Math.min(Number(c.req.query('days') ?? '30'), 365);
-  const result = await getGrowth(c.env.VSCODE_MARKETPLACE_BUCKET, extensionId, days);
-  return c.json(result);
+  try {
+    const extensionId = c.req.param('extensionId');
+    const days = parseBoundedInt(c.req.query('days'), 30, 1, 365);
+    const result = await getGrowth(c.env.VSCODE_MARKETPLACE_BUCKET, extensionId, days);
+    return c.json(result);
+  } catch (err) {
+    console.error('[repository] /growth error:', err);
+    return c.json({ error: 'Internal Server Error' }, 500);
+  }
 });
 
 // ----------------------------------------------------------------
 // GET /categories
 // ----------------------------------------------------------------
 app.get('/categories', async (c) => {
-  const result = await getCategories(c.env.VSCODE_MARKETPLACE_BUCKET);
-  return c.json(result);
+  try {
+    const result = await getCategories(c.env.VSCODE_MARKETPLACE_BUCKET);
+    return c.json(result);
+  } catch (err) {
+    console.error('[repository] /categories error:', err);
+    return c.json({ error: 'Internal Server Error' }, 500);
+  }
 });
 
 // ----------------------------------------------------------------
 // GET /search?q=<keyword>&limit=50
 // ----------------------------------------------------------------
 app.get('/search', async (c) => {
-  const query = c.req.query('q') ?? '';
-  const limit = Math.min(Number(c.req.query('limit') ?? '50'), 200);
-  if (!query) return c.json({ error: 'q is required' }, 400);
-  const result = await searchExtensions(c.env.VSCODE_MARKETPLACE_BUCKET, query, limit);
-  return c.json(result);
+  try {
+    const query = c.req.query('q') ?? '';
+    const limit = parseBoundedInt(c.req.query('limit'), 50, 1, 200);
+    if (!query) return c.json({ error: 'q is required' }, 400);
+    const result = await searchExtensions(c.env.VSCODE_MARKETPLACE_BUCKET, query, limit);
+    return c.json(result);
+  } catch (err) {
+    console.error('[repository] /search error:', err);
+    return c.json({ error: 'Internal Server Error' }, 500);
+  }
 });
 
 export default app;

--- a/apps/meguru/repository/src/index.ts
+++ b/apps/meguru/repository/src/index.ts
@@ -1,0 +1,83 @@
+import type { ExtensionSnapshot } from '@meguru/types';
+import { Hono } from 'hono';
+import {
+  getCategories,
+  getGrowth,
+  getTrending,
+  invalidateCaches,
+  searchExtensions,
+} from './aggregate.js';
+import { writeSnapshotChunk } from './r2.js';
+
+interface Env {
+  VSCODE_MARKETPLACE_BUCKET: R2Bucket;
+}
+
+const app = new Hono<{ Bindings: Env }>();
+
+// ----------------------------------------------------------------
+// POST /write  — collector writes snapshot batches here
+// Body: { date: string; records: ExtensionSnapshot[] }
+// ----------------------------------------------------------------
+app.post('/write', async (c) => {
+  const { date, records } = await c.req.json<{
+    date: string;
+    records: ExtensionSnapshot[];
+  }>();
+
+  if (!date || !Array.isArray(records)) {
+    return c.json({ error: 'date and records are required' }, 400);
+  }
+
+  await writeSnapshotChunk(c.env.VSCODE_MARKETPLACE_BUCKET, date, records);
+  return c.json({ ok: true, count: records.length });
+});
+
+// ----------------------------------------------------------------
+// POST /invalidate  — called after collection completes
+// ----------------------------------------------------------------
+app.post('/invalidate', async (c) => {
+  await invalidateCaches(c.env.VSCODE_MARKETPLACE_BUCKET);
+  return c.json({ ok: true });
+});
+
+// ----------------------------------------------------------------
+// GET /trending?period=weekly&limit=50
+// ----------------------------------------------------------------
+app.get('/trending', async (c) => {
+  const period = (c.req.query('period') ?? 'weekly') as 'daily' | 'weekly' | 'monthly';
+  const limit = Math.min(Number(c.req.query('limit') ?? '50'), 500);
+  const result = await getTrending(c.env.VSCODE_MARKETPLACE_BUCKET, period, limit);
+  return c.json(result);
+});
+
+// ----------------------------------------------------------------
+// GET /growth/:extensionId?days=30
+// ----------------------------------------------------------------
+app.get('/growth/:extensionId', async (c) => {
+  const extensionId = c.req.param('extensionId');
+  const days = Math.min(Number(c.req.query('days') ?? '30'), 365);
+  const result = await getGrowth(c.env.VSCODE_MARKETPLACE_BUCKET, extensionId, days);
+  return c.json(result);
+});
+
+// ----------------------------------------------------------------
+// GET /categories
+// ----------------------------------------------------------------
+app.get('/categories', async (c) => {
+  const result = await getCategories(c.env.VSCODE_MARKETPLACE_BUCKET);
+  return c.json(result);
+});
+
+// ----------------------------------------------------------------
+// GET /search?q=<keyword>&limit=50
+// ----------------------------------------------------------------
+app.get('/search', async (c) => {
+  const query = c.req.query('q') ?? '';
+  const limit = Math.min(Number(c.req.query('limit') ?? '50'), 200);
+  if (!query) return c.json({ error: 'q is required' }, 400);
+  const result = await searchExtensions(c.env.VSCODE_MARKETPLACE_BUCKET, query, limit);
+  return c.json(result);
+});
+
+export default app;

--- a/apps/meguru/repository/src/r2.ts
+++ b/apps/meguru/repository/src/r2.ts
@@ -71,7 +71,11 @@ export async function* iterateSnapshotRecords(
       for (const line of text.split('\n')) {
         const trimmed = line.trim();
         if (trimmed) {
-          yield JSON.parse(trimmed) as ExtensionSnapshot;
+          try {
+            yield JSON.parse(trimmed) as ExtensionSnapshot;
+          } catch (err) {
+            console.warn(`[r2] Skipping malformed NDJSON line in ${obj.key}:`, err);
+          }
         }
       }
     }

--- a/apps/meguru/repository/src/r2.ts
+++ b/apps/meguru/repository/src/r2.ts
@@ -1,0 +1,101 @@
+import type { ExtensionSnapshot } from '@meguru/types';
+
+const R2_PREFIX = 'vscode-marketplace';
+
+// ----------------------------------------------------------------
+// Write
+// ----------------------------------------------------------------
+
+/**
+ * Write a batch of ExtensionSnapshot records to R2 as NDJSON.
+ * Each batch is stored as a separate chunk file:
+ *   vscode-marketplace/snapshots/<date>/<timestamp>-<random>.ndjson
+ * Multiple chunks per date are expected (one per collector page).
+ */
+export async function writeSnapshotChunk(
+  bucket: R2Bucket,
+  date: string,
+  records: ExtensionSnapshot[],
+): Promise<void> {
+  const ndjson = records.map((r) => JSON.stringify(r)).join('\n');
+  const key = `${R2_PREFIX}/snapshots/${date}/${Date.now()}-${Math.random().toString(36).slice(2)}.ndjson`;
+  await bucket.put(key, ndjson, {
+    httpMetadata: { contentType: 'application/x-ndjson' },
+  });
+}
+
+// ----------------------------------------------------------------
+// Aggregated cache helpers
+// ----------------------------------------------------------------
+
+export async function readAggregated<T>(bucket: R2Bucket, key: string): Promise<T | null> {
+  const obj = await bucket.get(`${R2_PREFIX}/aggregated/${key}`);
+  if (!obj) return null;
+  try {
+    return (await obj.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeAggregated(bucket: R2Bucket, key: string, data: unknown): Promise<void> {
+  await bucket.put(`${R2_PREFIX}/aggregated/${key}`, JSON.stringify(data), {
+    httpMetadata: { contentType: 'application/json' },
+  });
+}
+
+// ----------------------------------------------------------------
+// Snapshot iteration
+// ----------------------------------------------------------------
+
+/**
+ * Iterate over all ExtensionSnapshot records for a given date.
+ * Reads all chunk files with prefix vscode-marketplace/snapshots/<date>/.
+ */
+export async function* iterateSnapshotRecords(
+  bucket: R2Bucket,
+  date: string,
+): AsyncGenerator<ExtensionSnapshot> {
+  const prefix = `${R2_PREFIX}/snapshots/${date}/`;
+  let cursor: string | undefined;
+
+  do {
+    const listed = await bucket.list(cursor ? { prefix, cursor } : { prefix });
+
+    for (const obj of listed.objects) {
+      const file = await bucket.get(obj.key);
+      if (!file) continue;
+      const text = await file.text();
+      for (const line of text.split('\n')) {
+        const trimmed = line.trim();
+        if (trimmed) {
+          yield JSON.parse(trimmed) as ExtensionSnapshot;
+        }
+      }
+    }
+
+    cursor = listed.truncated ? listed.cursor : undefined;
+  } while (cursor);
+}
+
+/**
+ * List available snapshot dates (most recent first).
+ */
+export async function listSnapshotDates(bucket: R2Bucket): Promise<string[]> {
+  const prefix = `${R2_PREFIX}/snapshots/`;
+  const dateSet = new Set<string>();
+  let cursor: string | undefined;
+
+  do {
+    const listed = await bucket.list(
+      cursor ? { prefix, delimiter: '/', cursor } : { prefix, delimiter: '/' },
+    );
+    for (const cp of listed.delimitedPrefixes) {
+      const date = cp.replace(prefix, '').replace('/', '');
+      if (date) dateSet.add(date);
+    }
+    cursor = listed.truncated ? listed.cursor : undefined;
+  } while (cursor);
+
+  return [...dateSet].sort().reverse();
+}

--- a/apps/meguru/repository/src/r2.ts
+++ b/apps/meguru/repository/src/r2.ts
@@ -67,7 +67,15 @@ export async function* iterateSnapshotRecords(
   let cursor: string | undefined;
 
   do {
-    const listed = await bucket.list(cursor ? { prefix, cursor } : { prefix });
+    let listed: R2Objects;
+    try {
+      listed = await bucket.list(cursor ? { prefix, cursor } : { prefix });
+    } catch (err) {
+      throw new Error(
+        `[r2] iterateSnapshotRecords: bucket.list failed (prefix=${prefix}, cursor=${cursor ?? 'none'}): ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
 
     for (const obj of listed.objects) {
       try {
@@ -102,9 +110,17 @@ export async function listSnapshotDates(bucket: R2Bucket): Promise<string[]> {
   let cursor: string | undefined;
 
   do {
-    const listed = await bucket.list(
-      cursor ? { prefix, delimiter: '/', cursor } : { prefix, delimiter: '/' },
-    );
+    let listed: R2Objects;
+    try {
+      listed = await bucket.list(
+        cursor ? { prefix, delimiter: '/', cursor } : { prefix, delimiter: '/' },
+      );
+    } catch (err) {
+      throw new Error(
+        `[r2] listSnapshotDates: bucket.list failed (prefix=${prefix}, cursor=${cursor ?? 'none'}): ${err instanceof Error ? err.message : String(err)}`,
+        { cause: err },
+      );
+    }
     for (const cp of listed.delimitedPrefixes) {
       const date = cp.replace(prefix, '').replace('/', '');
       if (date) dateSet.add(date);

--- a/apps/meguru/repository/src/r2.ts
+++ b/apps/meguru/repository/src/r2.ts
@@ -8,17 +8,19 @@ const R2_PREFIX = 'vscode-marketplace';
 
 /**
  * Write a batch of ExtensionSnapshot records to R2 as NDJSON.
- * Each batch is stored as a separate chunk file:
- *   vscode-marketplace/snapshots/<date>/<timestamp>-<random>.ndjson
- * Multiple chunks per date are expected (one per collector page).
+ * Each batch is stored as a deterministic chunk file:
+ *   vscode-marketplace/snapshots/<date>/<chunkId>.ndjson
+ * Using a deterministic chunkId (e.g. "page-1") ensures retries overwrite
+ * rather than appending duplicate records.
  */
 export async function writeSnapshotChunk(
   bucket: R2Bucket,
   date: string,
+  chunkId: string,
   records: ExtensionSnapshot[],
 ): Promise<void> {
   const ndjson = records.map((r) => JSON.stringify(r)).join('\n');
-  const key = `${R2_PREFIX}/snapshots/${date}/${Date.now()}-${Math.random().toString(36).slice(2)}.ndjson`;
+  const key = `${R2_PREFIX}/snapshots/${date}/${chunkId}.ndjson`;
   await bucket.put(key, ndjson, {
     httpMetadata: { contentType: 'application/x-ndjson' },
   });

--- a/apps/meguru/repository/src/r2.ts
+++ b/apps/meguru/repository/src/r2.ts
@@ -21,9 +21,13 @@ export async function writeSnapshotChunk(
 ): Promise<void> {
   const ndjson = records.map((r) => JSON.stringify(r)).join('\n');
   const key = `${R2_PREFIX}/snapshots/${date}/${chunkId}.ndjson`;
-  await bucket.put(key, ndjson, {
-    httpMetadata: { contentType: 'application/x-ndjson' },
-  });
+  try {
+    await bucket.put(key, ndjson, {
+      httpMetadata: { contentType: 'application/x-ndjson' },
+    });
+  } catch (err) {
+    throw new Error(`R2 write failed for key ${key}: ${err instanceof Error ? err.message : String(err)}`, { cause: err });
+  }
 }
 
 // ----------------------------------------------------------------

--- a/apps/meguru/repository/src/r2.ts
+++ b/apps/meguru/repository/src/r2.ts
@@ -41,9 +41,14 @@ export async function readAggregated<T>(bucket: R2Bucket, key: string): Promise<
 }
 
 export async function writeAggregated(bucket: R2Bucket, key: string, data: unknown): Promise<void> {
-  await bucket.put(`${R2_PREFIX}/aggregated/${key}`, JSON.stringify(data), {
-    httpMetadata: { contentType: 'application/json' },
-  });
+  try {
+    await bucket.put(`${R2_PREFIX}/aggregated/${key}`, JSON.stringify(data), {
+      httpMetadata: { contentType: 'application/json' },
+    });
+  } catch (err) {
+    console.error(`[r2] Failed to write aggregated cache ${key}:`, err);
+    throw err;
+  }
 }
 
 // ----------------------------------------------------------------
@@ -65,18 +70,22 @@ export async function* iterateSnapshotRecords(
     const listed = await bucket.list(cursor ? { prefix, cursor } : { prefix });
 
     for (const obj of listed.objects) {
-      const file = await bucket.get(obj.key);
-      if (!file) continue;
-      const text = await file.text();
-      for (const line of text.split('\n')) {
-        const trimmed = line.trim();
-        if (trimmed) {
-          try {
-            yield JSON.parse(trimmed) as ExtensionSnapshot;
-          } catch (err) {
-            console.warn(`[r2] Skipping malformed NDJSON line in ${obj.key}:`, err);
+      try {
+        const file = await bucket.get(obj.key);
+        if (!file) continue;
+        const text = await file.text();
+        for (const line of text.split('\n')) {
+          const trimmed = line.trim();
+          if (trimmed) {
+            try {
+              yield JSON.parse(trimmed) as ExtensionSnapshot;
+            } catch (err) {
+              console.warn(`[r2] Skipping malformed NDJSON line in ${obj.key}:`, err);
+            }
           }
         }
+      } catch (err) {
+        console.warn(`[r2] Failed to read chunk ${obj.key}, skipping:`, err);
       }
     }
 

--- a/apps/meguru/repository/tsconfig.json
+++ b/apps/meguru/repository/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "@tsconfig/strictest",
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ESNext"],
+    "types": ["@cloudflare/workers-types"],
+    "noEmit": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", ".wrangler"]
+}

--- a/apps/meguru/repository/wrangler.toml
+++ b/apps/meguru/repository/wrangler.toml
@@ -1,0 +1,12 @@
+name = "meguru-repository"
+main = "src/index.ts"
+compatibility_date = "2024-11-01"
+compatibility_flags = ["nodejs_compat"]
+
+# R2 bucket — create with: wrangler r2 bucket create meguru-vscode-marketplace
+[[r2_buckets]]
+binding = "VSCODE_MARKETPLACE_BUCKET"
+bucket_name = "meguru-vscode-marketplace"
+
+[dev]
+port = 8787

--- a/apps/meguru/repository/wrangler.toml
+++ b/apps/meguru/repository/wrangler.toml
@@ -3,6 +3,9 @@ main = "src/index.ts"
 compatibility_date = "2024-11-01"
 compatibility_flags = ["nodejs_compat"]
 
+# Set via: wrangler secret put INTERNAL_SECRET
+# Used to authenticate /write and /invalidate calls from collector
+
 # R2 bucket — create with: wrangler r2 bucket create meguru-vscode-marketplace
 [[r2_buckets]]
 binding = "VSCODE_MARKETPLACE_BUCKET"

--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,7 @@
       "name": "@meguru/cli",
       "version": "0.1.0",
       "bin": {
-        "meguru": "./src/index.ts",
+        "meguru": "./dist/meguru",
       },
       "dependencies": {
         "@meguru/types": "workspace:*",

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,77 @@
         "turbo": "^2.5.0",
       },
     },
+    "apps/meguru/cli": {
+      "name": "@meguru/cli",
+      "version": "0.1.0",
+      "bin": {
+        "meguru": "./src/index.ts",
+      },
+      "dependencies": {
+        "@meguru/types": "workspace:*",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "catalog:",
+        "bun-types": "^1.3.11",
+        "typescript": "catalog:",
+      },
+    },
+    "apps/meguru/collector": {
+      "name": "@meguru/collector",
+      "version": "0.1.0",
+      "dependencies": {
+        "@meguru/types": "workspace:*",
+        "hono": "^4.7.5",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "catalog:",
+        "@cloudflare/workers-types": "^4.20250409.0",
+        "typescript": "catalog:",
+        "wrangler": "^3.114.0",
+      },
+    },
+    "apps/meguru/dashboard": {
+      "name": "@meguru/dashboard",
+      "version": "0.1.0",
+      "dependencies": {
+        "@meguru/types": "workspace:*",
+        "hono": "^4.7.5",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "catalog:",
+        "@cloudflare/workers-types": "^4.20250409.0",
+        "typescript": "catalog:",
+        "wrangler": "^3.114.0",
+      },
+    },
+    "apps/meguru/gateway": {
+      "name": "@meguru/gateway",
+      "version": "0.1.0",
+      "dependencies": {
+        "@meguru/types": "workspace:*",
+        "hono": "^4.7.5",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "catalog:",
+        "@cloudflare/workers-types": "^4.20250409.0",
+        "typescript": "catalog:",
+        "wrangler": "^3.114.0",
+      },
+    },
+    "apps/meguru/repository": {
+      "name": "@meguru/repository",
+      "version": "0.1.0",
+      "dependencies": {
+        "@meguru/types": "workspace:*",
+        "hono": "^4.7.5",
+      },
+      "devDependencies": {
+        "@biomejs/biome": "catalog:",
+        "@cloudflare/workers-types": "^4.20250409.0",
+        "typescript": "catalog:",
+        "wrangler": "^3.114.0",
+      },
+    },
     "apps/meguru/vscode-marketplace-crawler": {
       "name": "@meguru/vscode-marketplace-crawler",
       "version": "0.1.0",
@@ -325,6 +396,13 @@
         "typescript": "catalog:",
       },
     },
+    "packages/meguru/types": {
+      "name": "@meguru/types",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "catalog:",
+      },
+    },
     "packages/suru/common/db": {
       "name": "@noos/suru-db",
       "version": "0.1.0",
@@ -547,6 +625,22 @@
 
     "@bufbuild/protoplugin": ["@bufbuild/protoplugin@1.10.1", "", { "dependencies": { "@bufbuild/protobuf": "1.10.1", "@typescript/vfs": "^1.4.0", "typescript": "4.5.2" } }, "sha512-LaSbfwabAFIvbVnbn8jWwElRoffCIxhVraO8arliVwWupWezHLXgqPHEYLXZY/SsAR+/YsFBQJa8tAGtNPJyaQ=="],
 
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.3.4", "", { "dependencies": { "mime": "^3.0.0" } }, "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.0.2", "", { "peerDependencies": { "unenv": "2.0.0-rc.14", "workerd": "^1.20250124.0" }, "optionalPeers": ["workerd"] }, "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20250718.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20250718.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20250718.0", "", { "os": "linux", "cpu": "x64" }, "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20250718.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20250718.0", "", { "os": "win32", "cpu": "x64" }, "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260409.1", "", {}, "sha512-0rGuppPeip6dqlI6013wC8tE+kbRK+tcaDfqCxKf9sEHDNfSWWUuKgIEDpt6IHHP2O0iYBQpngk5Siv4CL/HGQ=="],
+
     "@common/auth": ["@common/auth@workspace:packages/common/auth"],
 
     "@common/config": ["@common/config@workspace:packages/common/config"],
@@ -593,6 +687,8 @@
 
     "@crawlee/utils": ["@crawlee/utils@3.16.0", "", { "dependencies": { "@apify/log": "^2.4.0", "@apify/ps-tree": "^1.2.0", "@crawlee/types": "3.16.0", "@types/sax": "^1.2.7", "cheerio": "1.0.0-rc.12", "file-type": "^20.0.0", "got-scraping": "^4.0.3", "ow": "^0.28.1", "robots-parser": "^3.0.1", "sax": "^1.4.1", "tslib": "^2.4.0", "whatwg-mimetype": "^4.0.0" } }, "sha512-rfVx/3hsFZjiD4AwT8IoQsuNLiawrsdhc893Nha22mWQMxJ0Z/KUzh8FyJDnNOHuxWGIJP96I7nBikxYeSdw5A=="],
 
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
     "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
 
     "@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
@@ -611,59 +707,65 @@
 
     "@esbuild-kit/esm-loader": ["@esbuild-kit/esm-loader@2.6.5", "", { "dependencies": { "@esbuild-kit/core-utils": "^3.3.2", "get-tsconfig": "^4.7.0" } }, "sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA=="],
 
+    "@esbuild-plugins/node-globals-polyfill": ["@esbuild-plugins/node-globals-polyfill@0.2.3", "", { "peerDependencies": { "esbuild": "*" } }, "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw=="],
+
+    "@esbuild-plugins/node-modules-polyfill": ["@esbuild-plugins/node-modules-polyfill@0.2.2", "", { "dependencies": { "escape-string-regexp": "^4.0.0", "rollup-plugin-node-polyfills": "^0.2.1" }, "peerDependencies": { "esbuild": "*" } }, "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.7", "", { "os": "aix", "cpu": "ppc64" }, "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg=="],
 
-    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.17.19", "", { "os": "android", "cpu": "arm" }, "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A=="],
 
-    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.17.19", "", { "os": "android", "cpu": "arm64" }, "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA=="],
 
-    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.17.19", "", { "os": "android", "cpu": "x64" }, "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww=="],
 
-    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.17.19", "", { "os": "darwin", "cpu": "arm64" }, "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg=="],
 
-    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.17.19", "", { "os": "darwin", "cpu": "x64" }, "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw=="],
 
-    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.17.19", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ=="],
 
-    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.17.19", "", { "os": "freebsd", "cpu": "x64" }, "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ=="],
 
-    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.17.19", "", { "os": "linux", "cpu": "arm" }, "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA=="],
 
-    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.17.19", "", { "os": "linux", "cpu": "arm64" }, "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg=="],
 
-    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.17.19", "", { "os": "linux", "cpu": "ia32" }, "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ=="],
 
-    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.17.19", "", { "os": "linux", "cpu": "none" }, "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ=="],
 
-    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.17.19", "", { "os": "linux", "cpu": "none" }, "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A=="],
 
-    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.17.19", "", { "os": "linux", "cpu": "ppc64" }, "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg=="],
 
-    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.17.19", "", { "os": "linux", "cpu": "none" }, "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA=="],
 
-    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.17.19", "", { "os": "linux", "cpu": "s390x" }, "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q=="],
 
-    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.17.19", "", { "os": "linux", "cpu": "x64" }, "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw=="],
 
     "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w=="],
 
-    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.17.19", "", { "os": "none", "cpu": "x64" }, "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q=="],
 
     "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.7", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A=="],
 
-    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.17.19", "", { "os": "openbsd", "cpu": "x64" }, "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g=="],
 
     "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.7", "", { "os": "none", "cpu": "arm64" }, "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw=="],
 
-    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.17.19", "", { "os": "sunos", "cpu": "x64" }, "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg=="],
 
-    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.17.19", "", { "os": "win32", "cpu": "arm64" }, "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag=="],
 
-    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.17.19", "", { "os": "win32", "cpu": "ia32" }, "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw=="],
 
-    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.17.19", "", { "os": "win32", "cpu": "x64" }, "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA=="],
 
     "@fastify/ajv-compiler": ["@fastify/ajv-compiler@4.0.5", "", { "dependencies": { "ajv": "^8.12.0", "ajv-formats": "^3.0.1", "fast-uri": "^3.0.0" } }, "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A=="],
+
+    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
 
     "@fastify/error": ["@fastify/error@4.2.0", "", {}, "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ=="],
 
@@ -683,53 +785,53 @@
 
     "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
 
-    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
 
-    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
 
-    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="],
 
-    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="],
 
-    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="],
 
-    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="],
 
     "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
 
     "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
 
-    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.0.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA=="],
 
-    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="],
 
-    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="],
 
-    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="],
 
-    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" }, "os": "linux", "cpu": "arm" }, "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="],
 
-    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="],
 
     "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
 
     "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
 
-    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.0.4" }, "os": "linux", "cpu": "s390x" }, "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q=="],
 
-    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="],
 
-    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g=="],
 
-    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
 
-    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.33.5", "", { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" }, "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="],
 
     "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
 
-    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.33.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="],
 
-    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
 
     "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
 
@@ -754,6 +856,18 @@
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
     "@keyv/serialize": ["@keyv/serialize@1.1.1", "", {}, "sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA=="],
+
+    "@meguru/cli": ["@meguru/cli@workspace:apps/meguru/cli"],
+
+    "@meguru/collector": ["@meguru/collector@workspace:apps/meguru/collector"],
+
+    "@meguru/dashboard": ["@meguru/dashboard@workspace:apps/meguru/dashboard"],
+
+    "@meguru/gateway": ["@meguru/gateway@workspace:apps/meguru/gateway"],
+
+    "@meguru/repository": ["@meguru/repository@workspace:apps/meguru/repository"],
+
+    "@meguru/types": ["@meguru/types@workspace:packages/meguru/types"],
 
     "@meguru/vscode-marketplace-crawler": ["@meguru/vscode-marketplace-crawler@workspace:apps/meguru/vscode-marketplace-crawler"],
 
@@ -1025,6 +1139,10 @@
 
     "abstract-logging": ["abstract-logging@2.0.1", "", {}, "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="],
 
+    "acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
+
+    "acorn-walk": ["acorn-walk@8.3.2", "", {}, "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A=="],
+
     "adm-zip": ["adm-zip@0.5.17", "", {}, "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ=="],
 
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
@@ -1049,6 +1167,8 @@
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
+    "as-table": ["as-table@1.0.55", "", { "dependencies": { "printable-characters": "^1.0.42" } }, "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ=="],
+
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "ast-v8-to-istanbul": ["ast-v8-to-istanbul@0.3.12", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.31", "estree-walker": "^3.0.3", "js-tokens": "^10.0.0" } }, "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g=="],
@@ -1072,6 +1192,8 @@
     "bindings": ["bindings@1.5.0", "", { "dependencies": { "file-uri-to-path": "1.0.0" } }, "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ=="],
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
+
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
 
     "boolbase": ["boolbase@1.0.0", "", {}, "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="],
 
@@ -1133,9 +1255,13 @@
 
     "cluster-key-slot": ["cluster-key-slot@1.1.2", "", {}, "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA=="],
 
+    "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
+
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
 
     "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
@@ -1169,6 +1295,8 @@
 
     "csv-stringify": ["csv-stringify@6.7.0", "", {}, "sha512-UdtziYp5HuTz7e5j8Nvq+a/3HQo+2/aJZ9xntNTpmRRIg/3YYqDVgiS9fvAhtNbnyfbv2ZBe0bqCHqzhE7FqWQ=="],
 
+    "data-uri-to-buffer": ["data-uri-to-buffer@2.0.2", "", {}, "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA=="],
+
     "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
 
     "dclint": ["dclint@2.2.2", "", { "dependencies": { "ajv": "^8.17.1", "cosmiconfig": "^9.0.0", "picocolors": "^1.1.1", "yaml": "^2.6.0", "yargs": "^17.7.2" }, "bin": { "dclint": "bin/dclint.cjs" } }, "sha512-BNbsu9QiLU3I+shRYnusOP98ClDrCNRardoCHqfix8PREeb4gfcxDesPwnFgbMmIJuGeOaEWWI0+RA0hfLHdRA=="],
@@ -1184,6 +1312,8 @@
     "deep-extend": ["deep-extend@0.6.0", "", {}, "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="],
 
     "defaults": ["defaults@1.0.4", "", { "dependencies": { "clone": "^1.0.2" } }, "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A=="],
+
+    "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
     "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
@@ -1233,21 +1363,25 @@
 
     "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
 
-    "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
+    "esbuild": ["esbuild@0.17.19", "", { "optionalDependencies": { "@esbuild/android-arm": "0.17.19", "@esbuild/android-arm64": "0.17.19", "@esbuild/android-x64": "0.17.19", "@esbuild/darwin-arm64": "0.17.19", "@esbuild/darwin-x64": "0.17.19", "@esbuild/freebsd-arm64": "0.17.19", "@esbuild/freebsd-x64": "0.17.19", "@esbuild/linux-arm": "0.17.19", "@esbuild/linux-arm64": "0.17.19", "@esbuild/linux-ia32": "0.17.19", "@esbuild/linux-loong64": "0.17.19", "@esbuild/linux-mips64el": "0.17.19", "@esbuild/linux-ppc64": "0.17.19", "@esbuild/linux-riscv64": "0.17.19", "@esbuild/linux-s390x": "0.17.19", "@esbuild/linux-x64": "0.17.19", "@esbuild/netbsd-x64": "0.17.19", "@esbuild/openbsd-x64": "0.17.19", "@esbuild/sunos-x64": "0.17.19", "@esbuild/win32-arm64": "0.17.19", "@esbuild/win32-ia32": "0.17.19", "@esbuild/win32-x64": "0.17.19" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw=="],
 
     "esbuild-register": ["esbuild-register@3.6.0", "", { "dependencies": { "debug": "^4.3.4" }, "peerDependencies": { "esbuild": ">=0.12 <1" } }, "sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
-    "escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
 
     "event-stream": ["event-stream@3.3.4", "", { "dependencies": { "duplexer": "~0.1.1", "from": "~0", "map-stream": "~0.1.0", "pause-stream": "0.0.11", "split": "0.3", "stream-combiner": "~0.0.4", "through": "~2.3.1" } }, "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g=="],
 
+    "exit-hook": ["exit-hook@2.2.1", "", {}, "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw=="],
+
     "expand-template": ["expand-template@2.0.3", "", {}, "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="],
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "exsolve": ["exsolve@1.0.8", "", {}, "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA=="],
 
     "fast-decode-uri-component": ["fast-decode-uri-component@1.0.1", "", {}, "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg=="],
 
@@ -1309,6 +1443,8 @@
 
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
+    "get-source": ["get-source@2.0.12", "", { "dependencies": { "data-uri-to-buffer": "^2.0.0", "source-map": "^0.6.1" } }, "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w=="],
+
     "get-stream": ["get-stream@9.0.1", "", { "dependencies": { "@sec-ant/readable-stream": "^0.4.1", "is-stream": "^4.0.1" } }, "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA=="],
 
     "get-tsconfig": ["get-tsconfig@4.13.7", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q=="],
@@ -1320,6 +1456,8 @@
     "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "glob-to-regexp": ["glob-to-regexp@0.4.1", "", {}, "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw=="],
 
     "got": ["got@14.6.6", "", { "dependencies": { "@sindresorhus/is": "^7.0.1", "byte-counter": "^0.1.0", "cacheable-lookup": "^7.0.0", "cacheable-request": "^13.0.12", "decompress-response": "^10.0.0", "form-data-encoder": "^4.0.2", "http2-wrapper": "^2.2.1", "keyv": "^5.5.3", "lowercase-keys": "^3.0.0", "p-cancelable": "^4.0.1", "responselike": "^4.0.2", "type-fest": "^4.26.1" } }, "sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg=="],
 
@@ -1489,6 +1627,8 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
+
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
@@ -1496,6 +1636,8 @@
     "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
 
     "mimic-response": ["mimic-response@4.0.0", "", {}, "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg=="],
+
+    "miniflare": ["miniflare@3.20250718.3", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "acorn": "8.14.0", "acorn-walk": "8.3.2", "exit-hook": "2.2.1", "glob-to-regexp": "0.4.1", "stoppable": "1.1.0", "undici": "^5.28.5", "workerd": "1.20250718.0", "ws": "8.18.0", "youch": "3.3.4", "zod": "3.22.3" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
@@ -1520,6 +1662,8 @@
     "msgpackr": ["msgpackr@1.11.5", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA=="],
 
     "msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
+
+    "mustache": ["mustache@4.2.0", "", { "bin": { "mustache": "bin/mustache" } }, "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ=="],
 
     "mute-stream": ["mute-stream@0.0.8", "", {}, "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="],
 
@@ -1554,6 +1698,8 @@
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
+
+    "ohash": ["ohash@2.0.11", "", {}, "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ=="],
 
     "oidc-token-hash": ["oidc-token-hash@5.2.0", "", {}, "sha512-6gj2m8cJZ+iSW8bm0FXdGF0YhIQbKrfP4yWTNzxc31U6MOjfEmB1rHvlYvxI1B7t7BCi1F2vYTT6YhtQRG4hxw=="],
 
@@ -1596,6 +1742,8 @@
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -1646,6 +1794,8 @@
     "prebuild-install": ["prebuild-install@7.1.3", "", { "dependencies": { "detect-libc": "^2.0.0", "expand-template": "^2.0.3", "github-from-package": "0.0.0", "minimist": "^1.2.3", "mkdirp-classic": "^0.5.3", "napi-build-utils": "^2.0.0", "node-abi": "^3.3.0", "pump": "^3.0.0", "rc": "^1.2.7", "simple-get": "^4.0.0", "tar-fs": "^2.0.0", "tunnel-agent": "^0.6.0" }, "bin": { "prebuild-install": "bin.js" } }, "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug=="],
 
     "pretty-format": ["pretty-format@3.8.0", "", {}, "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew=="],
+
+    "printable-characters": ["printable-characters@1.0.42", "", {}, "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ=="],
 
     "prisma": ["prisma@5.22.0", "", { "dependencies": { "@prisma/engines": "5.22.0" }, "optionalDependencies": { "fsevents": "2.3.3" }, "bin": { "prisma": "build/index.js" } }, "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A=="],
 
@@ -1717,6 +1867,12 @@
 
     "rollup": ["rollup@4.60.1", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.1", "@rollup/rollup-android-arm64": "4.60.1", "@rollup/rollup-darwin-arm64": "4.60.1", "@rollup/rollup-darwin-x64": "4.60.1", "@rollup/rollup-freebsd-arm64": "4.60.1", "@rollup/rollup-freebsd-x64": "4.60.1", "@rollup/rollup-linux-arm-gnueabihf": "4.60.1", "@rollup/rollup-linux-arm-musleabihf": "4.60.1", "@rollup/rollup-linux-arm64-gnu": "4.60.1", "@rollup/rollup-linux-arm64-musl": "4.60.1", "@rollup/rollup-linux-loong64-gnu": "4.60.1", "@rollup/rollup-linux-loong64-musl": "4.60.1", "@rollup/rollup-linux-ppc64-gnu": "4.60.1", "@rollup/rollup-linux-ppc64-musl": "4.60.1", "@rollup/rollup-linux-riscv64-gnu": "4.60.1", "@rollup/rollup-linux-riscv64-musl": "4.60.1", "@rollup/rollup-linux-s390x-gnu": "4.60.1", "@rollup/rollup-linux-x64-gnu": "4.60.1", "@rollup/rollup-linux-x64-musl": "4.60.1", "@rollup/rollup-openbsd-x64": "4.60.1", "@rollup/rollup-openharmony-arm64": "4.60.1", "@rollup/rollup-win32-arm64-msvc": "4.60.1", "@rollup/rollup-win32-ia32-msvc": "4.60.1", "@rollup/rollup-win32-x64-gnu": "4.60.1", "@rollup/rollup-win32-x64-msvc": "4.60.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w=="],
 
+    "rollup-plugin-inject": ["rollup-plugin-inject@3.0.2", "", { "dependencies": { "estree-walker": "^0.6.1", "magic-string": "^0.25.3", "rollup-pluginutils": "^2.8.1" } }, "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w=="],
+
+    "rollup-plugin-node-polyfills": ["rollup-plugin-node-polyfills@0.2.1", "", { "dependencies": { "rollup-plugin-inject": "^3.0.0" } }, "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA=="],
+
+    "rollup-pluginutils": ["rollup-pluginutils@2.8.2", "", { "dependencies": { "estree-walker": "^0.6.1" } }, "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ=="],
+
     "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
 
     "run-async": ["run-async@2.4.1", "", {}, "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ=="],
@@ -1749,7 +1905,7 @@
 
     "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
-    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+    "sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -1762,6 +1918,8 @@
     "simple-concat": ["simple-concat@1.0.1", "", {}, "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="],
 
     "simple-get": ["simple-get@4.0.1", "", { "dependencies": { "decompress-response": "^6.0.0", "once": "^1.3.1", "simple-concat": "^1.0.0" } }, "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA=="],
+
+    "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
 
     "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
 
@@ -1781,15 +1939,21 @@
 
     "source-map-support": ["source-map-support@0.5.21", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w=="],
 
+    "sourcemap-codec": ["sourcemap-codec@1.4.8", "", {}, "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="],
+
     "split": ["split@0.3.3", "", { "dependencies": { "through": "2" } }, "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
+    "stacktracey": ["stacktracey@2.2.0", "", { "dependencies": { "as-table": "^1.0.36", "get-source": "^2.0.12" } }, "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg=="],
+
     "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
 
     "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "stoppable": ["stoppable@1.1.0", "", {}, "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw=="],
 
     "stream-chain": ["stream-chain@2.2.5", "", {}, "sha512-1TJmBx6aSWqZ4tx7aTpBDXK0/e2hhcNSTV8+CbFJtDjbb+I1mZ8lHit0Grw9GRT+6JbIrrDd8esncgBi8aBXGA=="],
 
@@ -1883,11 +2047,17 @@
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
+    "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
+
     "uhyphen": ["uhyphen@0.2.0", "", {}, "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA=="],
 
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
+    "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
+
     "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "unenv": ["unenv@2.0.0-rc.14", "", { "dependencies": { "defu": "^6.1.4", "exsolve": "^1.0.1", "ohash": "^2.0.10", "pathe": "^2.0.3", "ufo": "^1.5.4" } }, "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q=="],
 
     "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
 
@@ -1923,13 +2093,17 @@
 
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
+    "workerd": ["workerd@1.20250718.0", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20250718.0", "@cloudflare/workerd-darwin-arm64": "1.20250718.0", "@cloudflare/workerd-linux-64": "1.20250718.0", "@cloudflare/workerd-linux-arm64": "1.20250718.0", "@cloudflare/workerd-windows-64": "1.20250718.0" }, "bin": { "workerd": "bin/workerd" } }, "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg=="],
+
+    "wrangler": ["wrangler@3.114.17", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.3.4", "@cloudflare/unenv-preset": "2.0.2", "@esbuild-plugins/node-globals-polyfill": "0.2.3", "@esbuild-plugins/node-modules-polyfill": "0.2.2", "blake3-wasm": "2.1.5", "esbuild": "0.17.19", "miniflare": "3.20250718.3", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.14", "workerd": "1.20250718.0" }, "optionalDependencies": { "fsevents": "~2.3.2", "sharp": "^0.33.5" }, "peerDependencies": { "@cloudflare/workers-types": "^4.20250408.0" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js" } }, "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA=="],
+
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+    "ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
 
     "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
 
@@ -1950,6 +2124,8 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
+
+    "youch": ["youch@3.3.4", "", { "dependencies": { "cookie": "^0.7.1", "mustache": "^4.2.0", "stacktracey": "^2.1.8" } }, "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
@@ -1978,6 +2154,8 @@
     "@crawlee/core/tough-cookie": ["tough-cookie@6.0.1", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw=="],
 
     "@crawlee/templates/inquirer": ["inquirer@9.3.8", "", { "dependencies": { "@inquirer/external-editor": "^1.0.2", "@inquirer/figures": "^1.0.3", "ansi-escapes": "^4.3.2", "cli-width": "^4.1.0", "mute-stream": "1.0.0", "ora": "^5.4.1", "run-async": "^3.0.0", "rxjs": "^7.8.1", "string-width": "^4.2.3", "strip-ansi": "^6.0.1", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.2" } }, "sha512-pFGGdaHrmRKMh4WoDDSowddgjT1Vkl90atobmTeSmcPGdYiwikch/m/Ef5wRaiamHejtw0cUUMMerzDUXCci2w=="],
+
+    "@cspotcode/source-map-support/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
 
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
@@ -2037,6 +2215,8 @@
 
     "figlet/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
+    "figures/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
     "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
 
     "got/@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
@@ -2053,6 +2233,8 @@
 
     "inquirer/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
+    "jsdom/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
+
     "light-my-request/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "light-my-request/process-warning": ["process-warning@4.0.1", "", {}, "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q=="],
@@ -2065,7 +2247,11 @@
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "miniflare/zod": ["zod@3.22.3", "", {}, "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug=="],
+
     "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "next/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
     "next-auth/uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
@@ -2085,9 +2271,19 @@
 
     "restore-cursor/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
+    "rollup-plugin-inject/estree-walker": ["estree-walker@0.6.1", "", {}, "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="],
+
+    "rollup-plugin-inject/magic-string": ["magic-string@0.25.9", "", { "dependencies": { "sourcemap-codec": "^1.4.8" } }, "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ=="],
+
+    "rollup-pluginutils/estree-walker": ["estree-walker@0.6.1", "", {}, "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w=="],
+
+    "simple-swizzle/is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
+
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
 
     "tough-cookie/tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
+
+    "tsx/esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
     "vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
@@ -2411,7 +2607,89 @@
 
     "linkedom/htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
+    "next/sharp/@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "next/sharp/@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "next/sharp/@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "next/sharp/@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "next/sharp/@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "next/sharp/@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "next/sharp/@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "next/sharp/@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "next/sharp/@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "next/sharp/@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "next/sharp/@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "next/sharp/@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "next/sharp/@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "next/sharp/@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "next/sharp/@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "next/sharp/@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "next/sharp/@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "next/sharp/@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "next/sharp/@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
     "tough-cookie/tldts/tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
+
+    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.27.7", "", { "os": "android", "cpu": "arm" }, "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ=="],
+
+    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.7", "", { "os": "android", "cpu": "arm64" }, "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ=="],
+
+    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.27.7", "", { "os": "android", "cpu": "x64" }, "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg=="],
+
+    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw=="],
+
+    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ=="],
+
+    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.7", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w=="],
+
+    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ=="],
+
+    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.7", "", { "os": "linux", "cpu": "arm" }, "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA=="],
+
+    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A=="],
+
+    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.7", "", { "os": "linux", "cpu": "ia32" }, "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg=="],
+
+    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q=="],
+
+    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw=="],
+
+    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ=="],
+
+    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.7", "", { "os": "linux", "cpu": "none" }, "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ=="],
+
+    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw=="],
+
+    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.7", "", { "os": "linux", "cpu": "x64" }, "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA=="],
+
+    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.7", "", { "os": "none", "cpu": "x64" }, "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw=="],
+
+    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.7", "", { "os": "openbsd", "cpu": "x64" }, "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg=="],
+
+    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.7", "", { "os": "sunos", "cpu": "x64" }, "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA=="],
+
+    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA=="],
+
+    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.7", "", { "os": "win32", "cpu": "ia32" }, "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw=="],
+
+    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.7", "", { "os": "win32", "cpu": "x64" }, "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg=="],
 
     "vite-node/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
@@ -2464,6 +2742,8 @@
     "vitest/vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "yargonaut/chalk/ansi-styles": ["ansi-styles@2.2.1", "", {}, "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA=="],
+
+    "yargonaut/chalk/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "yargonaut/chalk/strip-ansi": ["strip-ansi@3.0.1", "", { "dependencies": { "ansi-regex": "^2.0.0" } }, "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg=="],
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
       "apps/suru/*",
       "apps/suru/services/*",
       "packages/common/*",
+      "packages/meguru/*",
       "packages/yomu/*",
       "packages/suru/common/*",
       "tooling/*"

--- a/packages/meguru/types/package.json
+++ b/packages/meguru/types/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@meguru/types",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
+    "clean": "rm -rf dist .turbo node_modules"
+  },
+  "devDependencies": {
+    "typescript": "catalog:"
+  }
+}

--- a/packages/meguru/types/src/index.ts
+++ b/packages/meguru/types/src/index.ts
@@ -1,0 +1,101 @@
+// ============================================================
+// Extension snapshot — 1 record = 1 extension per day
+// Stored as NDJSON in R2: vscode-marketplace/snapshots/<date>/<chunk>.ndjson
+// ============================================================
+
+export interface ExtensionSnapshot {
+  // === 識別 ===
+  extension_id: string; // UUID
+  name: string; // "publisher.extensionName"
+  display_name: string;
+  snapshot_date: string; // "YYYY-MM-DD"
+
+  // === パブリッシャー ===
+  publisher_id: string;
+  publisher_name: string;
+  publisher_display_name: string;
+  publisher_domain: string | null;
+  publisher_domain_verified: boolean;
+  publisher_verified: boolean;
+
+  // === メタデータ ===
+  short_description: string | null;
+  categories: string[];
+  tags: string[];
+  published_date: string; // ISO 8601
+  release_date: string; // 初回リリース日
+  last_updated: string; // ISO 8601
+
+  // === 統計 (日次変動を追跡) ===
+  install_count: number | null;
+  download_count: number | null;
+  average_rating: number | null;
+  rating_count: number | null;
+  weighted_rating: number | null;
+  trending_daily: number | null;
+  trending_weekly: number | null;
+  trending_monthly: number | null;
+  update_count: number | null;
+
+  // === バージョン情報 ===
+  latest_version: string | null;
+  target_platform: string | null;
+  engine: string | null; // VS Code 互換バージョン e.g. "^1.95.0"
+  is_pre_release: boolean;
+  pricing: string | null; // "Free" | "Trial" | ...
+  executes_code: boolean;
+
+  // === 依存関係グラフ ===
+  extension_dependencies: string[];
+  extension_pack: string[];
+  extension_kind: string[]; // "workspace" | "ui" | "web"
+}
+
+// ============================================================
+// API response types (gateway → cli / browser)
+// ============================================================
+
+export interface TrendingItem {
+  extension_id: string;
+  name: string;
+  display_name: string;
+  publisher_name: string;
+  install_count: number | null;
+  trending_weekly: number | null;
+  trending_daily: number | null;
+  trending_monthly: number | null;
+  average_rating: number | null;
+  categories: string[];
+}
+
+export interface GrowthPoint {
+  date: string;
+  install_count: number | null;
+  trending_weekly: number | null;
+}
+
+export interface CategorySummary {
+  category: string;
+  total_extensions: number;
+  total_installs: number;
+}
+
+export interface SearchResult {
+  extension_id: string;
+  name: string;
+  display_name: string;
+  publisher_name: string;
+  short_description: string | null;
+  install_count: number | null;
+  average_rating: number | null;
+  categories: string[];
+}
+
+// ============================================================
+// Queue message shape (collector → Queue)
+// ============================================================
+
+export interface CrawlQueueMessage {
+  pageNumber: number;
+  snapshotDate: string;
+}

--- a/packages/meguru/types/tsconfig.json
+++ b/packages/meguru/types/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tooling/tsconfig/base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "tsBuildInfoFile": ".tsbuildinfo"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
Closes #43

## 概要

VSCode Marketplace Crawler を Docker + PostgreSQL から **Cloudflare Workers + R2 + NDJSON** アーキテクチャに全面移行。

ADR: `docs/flow/design-docs/meguru/vscode-marketplace/v1.0.0/adr/`

## 実装内容

### 新規パッケージ

| パッケージ | 役割 |
|---|---|
| `packages/meguru/types` | 共有型定義 (`ExtensionSnapshot`, `TrendingItem`, etc.) |
| `apps/meguru/repository` | R2 NDJSON 書き込み・集計 API (Service Binding) |
| `apps/meguru/collector` | Marketplace API クローラー + Queue ページング |
| `apps/meguru/gateway` | 外部向け HTTP API |
| `apps/meguru/cli` | `meguru` CLI ツール |
| `apps/meguru/dashboard` | Hono JSX SSR ブラウザUI |

### 主な変更点

- **API flags**: 914 → **950** (categories / tags / version properties 追加)
- **リトライ**: 3回固定 → **指数バックオフ 5回** (1s, 2s, 4s, 8s)
- **ストレージ**: PostgreSQL → **R2 NDJSON** (~7MB/day gzip, 年間 ~2.5GB)
- **スケジューラ**: Docker Cron → **Cloudflare Cron Trigger + Queues**
- **フィールド数**: ~15 → **~30** (weighted_rating, engine, extension_kind 等)
- **GitHub Actions**: コンポーネント単位の差分デプロイ (paths filter)

## デプロイ手順 (初回)

```bash
# 1. Cloudflare リソース作成
wrangler r2 bucket create meguru-vscode-marketplace
wrangler queues create meguru-crawl-queue
wrangler queues create meguru-crawl-dlq

# 2. Phase 1 → 5 の順でデプロイ
cd apps/meguru/repository  && wrangler deploy
cd apps/meguru/collector   && wrangler deploy
cd apps/meguru/gateway     && wrangler deploy
cd apps/meguru/dashboard   && wrangler deploy
```

## CI チェック

- [x] TypeScript 型チェック: 全 5 コンポーネントでパス
- [x] Biome lint/format: エラーなし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * CLI、ダッシュボード、ゲートウェイ、コレクター、リポジトリ、型パッケージを追加。CLIは複数コマンドとjson/table/text出力を提供。コレクターは日次スケジュール＋キューで段階的収集と内部書き込み／キャッシュ無効化を実行。リポジトリはスナップショット保管、集計キャッシュ、検索／トレンド／成長／カテゴリAPIを公開。ダッシュボードはSSR表示、ゲートウェイはAPIプロキシを追加。
* **雑務**
  * 各サービス向けの自動デプロイワークフローとモノレポワークスペース設定を追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->